### PR TITLE
Label Xorg server binary correctly on Debian

### DIFF
--- a/policy/modules/services/xserver.fc
+++ b/policy/modules/services/xserver.fc
@@ -70,6 +70,8 @@ HOME_DIR/\.Xauthority.*	--	gen_context(system_u:object_r:xauth_home_t,s0)
 /usr/bin/Xorg		--	gen_context(system_u:object_r:xserver_exec_t,s0)
 
 /usr/lib/qt-.*/etc/settings(/.*)? gen_context(system_u:object_r:xdm_var_run_t,s0)
+/usr/lib/xorg/Xorg		--	gen_context(system_u:object_r:xserver_exec_t,s0)
+/usr/lib/xorg/Xorg\.wrap	--	gen_context(system_u:object_r:xserver_exec_t,s0)
 /usr/lib/xorg-server/Xorg	--	gen_context(system_u:object_r:xserver_exec_t,s0)
 /usr/lib/xorg-server/Xorg\.wrap	--	gen_context(system_u:object_r:xserver_exec_t,s0)
 


### PR DESCRIPTION
On Debian, /usr/bin/Xorg is only a shell script which executes
/usr/lib/xorg/Xorg.wrap, which is a SUID binary wrapper around
/usr/lib/xorg/Xorg.