### PR TITLE
Allow systemd the audit_read capability

### DIFF
--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -195,7 +195,7 @@ ifdef(`init_systemd',`
 	typeattribute init_t init_run_all_scripts_domain;
 
 	allow init_t self:process { getcap getsched setsched setpgid setfscreate setsockcreate setcap setrlimit };
-	allow init_t self:capability2 block_suspend;
+	allow init_t self:capability2 { audit_read block_suspend };
 	allow init_t self:netlink_kobject_uevent_socket create_socket_perms;
 	allow init_t self:netlink_route_socket create_netlink_socket_perms;
 	allow init_t self:netlink_selinux_socket create_socket_perms;


### PR DESCRIPTION
At early boot, I get the following messages in dmesg:

audit: type=1400 audit(1452851002.184:3): avc:  denied  { audit_read } for  pid=1 comm="systemd" capability=37 scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=capability2 permissive=1
systemd[1]: Listening on Journal Audit Socket.