### PR TITLE
Several typo fixes

### DIFF
--- a/man/man8/git_selinux.8
+++ b/man/man8/git_selinux.8
@@ -64,7 +64,7 @@ To allow the Git System daemon mass hosting of users personal repositories you c
 sudo setsebool -P git_session_bind_all_unreserved_ports 1
 .EE
 .SH GIT_SHELL
-The Git policy by default provides a restricted user environment to be used with "Git shell". This default git_shell_u SELinux user can modify and execute generic Git system content (generic system shared respositories with type git_system_content_t).
+The Git policy by default provides a restricted user environment to be used with "Git shell". This default git_shell_u SELinux user can modify and execute generic Git system content (generic system shared repositories with type git_system_content_t).
 .PP
 To add a new Linux user and map him to this Git shell user domain automatically:
 .EX

--- a/man/man8/httpd_selinux.8
+++ b/man/man8/httpd_selinux.8
@@ -88,7 +88,7 @@ setsebool -P httpd_unified 0
 .EE
 
 .PP
-SELinu policy for httpd can be configured to turn on sending email. This is a security feature, since it would prevent a vulnerabiltiy in http from causing a spam attack.  I certain situations, you may want http modules to send mail.  You can turn on the httpd_send_mail boolean.
+SELinux policy for httpd can be configured to turn on sending email. This is a security feature, since it would prevent a vulnerability in http from causing a spam attack.  I certain situations, you may want http modules to send mail.  You can turn on the httpd_send_mail boolean.
 
 .EX
 setsebool -P httpd_can_sendmail 1

--- a/policy/modules/admin/bootloader.if
+++ b/policy/modules/admin/bootloader.if
@@ -124,8 +124,8 @@ interface(`bootloader_rw_tmp_files',`
 
 ########################################
 ## <summary>
-##	Read and write the bootloader
-##	temporary data in /tmp.
+##	Create, read and write the bootloader
+##	runtime data.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/policy/modules/kernel/corecommands.if
+++ b/policy/modules/kernel/corecommands.if
@@ -199,11 +199,11 @@ interface(`corecmd_getattr_bin_files',`
 
 ########################################
 ## <summary>
-##	Get the attributes of files in bin directories.
+##	Do not audit attempts to get the attributes of files in bin directories.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
-##	Domain allowed access.
+##	Domain to not audit.
 ##	</summary>
 ## </param>
 #

--- a/policy/modules/kernel/corenetwork.if.in
+++ b/policy/modules/kernel/corenetwork.if.in
@@ -855,7 +855,7 @@ interface(`corenet_udp_bind_generic_node',`
 
 ########################################
 ## <summary>
-##	Bind raw sockets to genric nodes.
+##	Bind raw sockets to generic nodes.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/policy/modules/kernel/corenetwork.if.in
+++ b/policy/modules/kernel/corenetwork.if.in
@@ -2734,12 +2734,12 @@ interface(`corenet_all_recvfrom_labeled',`
 
 ########################################
 ## <summary>
-##	Make the specified type usable
-##	for labeled ipsec.
+##	Allow specified type to set the context of
+##	a SPD entry for labeled ipsec associations.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
-##	Type to be used for labeled ipsec.
+##	Domain allowed access.
 ##	</summary>
 ## </param>
 #

--- a/policy/modules/kernel/corenetwork.if.m4
+++ b/policy/modules/kernel/corenetwork.if.m4
@@ -820,7 +820,7 @@ define(`network_node',`
 create_node_type_interfaces($1)
 ')
 
-# These next three macros have formatting, and should not me indented
+# These next three macros have formatting, and should not be indented
 define(`determine_reserved_capability',`dnl
 ifelse($2,`',`',`dnl
 ifelse(eval($2 < 1024),1,``allow' dollarsone self:capability net_bind_service;',`dnl

--- a/policy/modules/kernel/devices.if
+++ b/policy/modules/kernel/devices.if
@@ -227,7 +227,7 @@ interface(`dev_add_entry_generic_dirs',`
 
 ########################################
 ## <summary>
-##	Add entries to directories in /dev.
+##	Remove entries from directories in /dev.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -2023,7 +2023,7 @@ interface(`dev_read_input',`
 
 ########################################
 ## <summary>
-##	Read input event devices (/dev/input).
+##	Read and write input event devices (/dev/input).
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/policy/modules/kernel/domain.if
+++ b/policy/modules/kernel/domain.if
@@ -1155,7 +1155,7 @@ interface(`domain_getattr_all_stream_sockets',`
 ########################################
 ## <summary>
 ##	Do not audit attempts to get the attributes
-##	of all domains unix datagram sockets.
+##	of all domains unix stream sockets.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/policy/modules/kernel/files.if
+++ b/policy/modules/kernel/files.if
@@ -1317,7 +1317,7 @@ interface(`files_relabelto_all_file_type_fs',`
 
 ########################################
 ## <summary>
-##	Relabel a filesystem to the type of a file.
+##	Relabel a filesystem to and from the type of a file.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -1399,7 +1399,7 @@ interface(`fs_read_cifs_named_pipes',`
 
 ########################################
 ## <summary>
-##	Read named pipes
+##	Read named sockets
 ##	on a CIFS or SMB network filesystem.
 ## </summary>
 ## <param name="domain">
@@ -2360,8 +2360,8 @@ interface(`fs_getattr_iso9660_fs',`
 
 ########################################
 ## <summary>
-##	Read files on an iso9660 filesystem, which
-##	is usually used on CDs.
+##	Get the attributes of files on an iso9660
+##	filesystem, which is usually used on CDs.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -2759,7 +2759,8 @@ interface(`fs_read_nfs_named_pipes',`
 
 ########################################
 ## <summary>
-##	Read directories of RPC file system pipes.
+##	Get the attributes of directories of RPC
+##	file system pipes.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/policy/modules/kernel/kernel.if
+++ b/policy/modules/kernel/kernel.if
@@ -1087,7 +1087,7 @@ interface(`kernel_dontaudit_read_system_state',`
 ########################################
 ## <summary>
 ##	Do not audit attempts by caller to
-##	read system state information in proc.
+##	read symbolic links in proc.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/policy/modules/kernel/storage.if
+++ b/policy/modules/kernel/storage.if
@@ -210,7 +210,7 @@ interface(`storage_create_fixed_disk_dev',`
 
 ########################################
 ## <summary>
-##	Allow the caller to create fixed disk device nodes.
+##	Allow the caller to delete fixed disk device nodes.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -738,7 +738,7 @@ interface(`storage_read_tape',`
 
 ########################################
 ## <summary>
-##	Allow the caller to directly read
+##	Allow the caller to directly write
 ##	a tape device.
 ## </summary>
 ## <param name="domain">

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -966,7 +966,7 @@ interface(`init_service_start',`
 #
 interface(`init_dbus_chat',`
 	gen_require(`
-		type initrc_t;
+		type init_t;
 		class dbus send_msg;
 	')
 

--- a/policy/modules/system/iptables.if
+++ b/policy/modules/system/iptables.if
@@ -70,7 +70,8 @@ interface(`iptables_exec',`
 
 #####################################
 ## <summary>
-##	Execute iptables in the iptables domain.
+##	Execute iptables init scripts in
+##	the init script domain.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/policy/modules/system/locallogin.if
+++ b/policy/modules/system/locallogin.if
@@ -135,7 +135,7 @@ interface(`locallogin_link_keys',`
 
 ########################################
 ## <summary>
-##	Execute local logins in the local login domain.
+##	Execute single-user logins in the single-user login domain.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/policy/modules/system/miscfiles.if
+++ b/policy/modules/system/miscfiles.if
@@ -771,7 +771,8 @@ interface(`miscfiles_exec_test_files',`
 
 ########################################
 ## <summary>
-##	Execute test files.
+##	Create files in etc directories
+##	with localization file type.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/policy/modules/system/modutils.if
+++ b/policy/modules/system/modutils.if
@@ -273,7 +273,7 @@ interface(`modutils_exec_depmod',`
 
 ########################################
 ## <summary>
-##	Execute depmod in the depmod domain.
+##	Execute update_modules in the update_modules domain.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/policy/modules/system/selinuxutil.if
+++ b/policy/modules/system/selinuxutil.if
@@ -762,7 +762,7 @@ interface(`seutil_manage_config',`
 #######################################
 ## <summary>
 ##	Create, read, write, and delete
-##	the general selinux configuration files.
+##	the general selinux configuration directories.
 ## </summary>
 ## <param name="domain">
 ##	<summary>

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1597,7 +1597,7 @@ interface(`userdom_create_user_home_dirs',`
 
 ########################################
 ## <summary>
-##	Create user home directories.
+##	Manage user home directories.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -1978,7 +1978,7 @@ interface(`userdom_delete_user_home_content_files',`
 
 ########################################
 ## <summary>
-##	Do not audit attempts to write user home files.
+##	Do not audit attempts to relabel user home files.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -2238,8 +2238,9 @@ interface(`userdom_user_home_dir_filetrans',`
 
 ########################################
 ## <summary>
-##	Create objects in a user home directory
-##	with an automatic type transition to
+##	Create objects in a directory located
+##	in a user home directory with an
+##	automatic type transition to
 ##	a specified private type.
 ## </summary>
 ## <param name="domain">
@@ -2685,7 +2686,7 @@ interface(`userdom_read_user_tmpfs_files',`
 
 ########################################
 ## <summary>
-##	Read user tmpfs files.
+##	Read and write user tmpfs files.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -2932,7 +2933,7 @@ interface(`userdom_spec_domtrans_all_users',`
 
 ########################################
 ## <summary>
-##	Execute an Xserver session in all unprivileged user domains.  This
+##	Execute an Xserver session in all user domains.  This
 ##	is an explicit transition, requiring the
 ##	caller to use setexeccon().
 ## </summary>


### PR DESCRIPTION
Hello,
Here are some commits which fix some typographical errors I found in refpolicy, either by encountering them in manual file inspection (like the typo in init_dbus_chat interface and the ones in the corenetwork module), by grabbing them from other issues (I posted a comment in PR https://github.com/TresysTechnology/refpolicy/pull/7 almost one year ago which got no reply) and by using a dirty script which finds interfaces sharing the same comment (in order to find copy-and-paste errors). Could you please merge them?
Cheers!