### PR TITLE
Allow {eb,ip,ip6}tables-restore to read files in /run/firewalld

### DIFF
--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -111,6 +111,7 @@ optional_policy(`
 
 optional_policy(`
 	firewalld_read_config_files(iptables_t)
+	firewalld_read_var_run_files(iptables_t)
 	firewalld_dontaudit_rw_tmp_files(iptables_t)
 ')
 


### PR DESCRIPTION
Since version 0.4.0, firewalld uses *tables-restore to speedup the
load of the rules