### PR TITLE
Add lxc_contexts config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ seusers := $(appconf)/seusers
 appdir := $(contextpath)
 user_default_contexts := $(wildcard config/appconfig-$(TYPE)/*_default_contexts)
 user_default_contexts_names := $(addprefix $(contextpath)/users/,$(subst _default_contexts,,$(notdir $(user_default_contexts))))
-appfiles := $(addprefix $(appdir)/,default_contexts default_type initrc_context failsafe_context userhelper_context removable_context dbus_contexts sepgsql_contexts x_contexts customizable_types securetty_types virtual_domain_context virtual_image_context) $(contextpath)/files/media $(fcsubspath) $(user_default_contexts_names)
+appfiles := $(addprefix $(appdir)/,default_contexts default_type initrc_context failsafe_context userhelper_context removable_context dbus_contexts sepgsql_contexts x_contexts customizable_types securetty_types lxc_contexts virtual_domain_context virtual_image_context) $(contextpath)/files/media $(fcsubspath) $(user_default_contexts_names)
 net_contexts := $(builddir)net_contexts
 
 all_layers := $(shell find $(wildcard $(moddir)/*) -maxdepth 0 -type d)

--- a/config/appconfig-mcs/lxc_contexts
+++ b/config/appconfig-mcs/lxc_contexts
@@ -1,0 +1,3 @@
+process = "system_u:system_r:svirt_lxc_net_t:s0"
+content = "system_u:object_r:virt_var_lib_t:s0"
+file = "system_u:object_r:svirt_lxc_file_t:s0"

--- a/config/appconfig-mls/lxc_contexts
+++ b/config/appconfig-mls/lxc_contexts
@@ -1,0 +1,3 @@
+process = "system_u:system_r:svirt_lxc_net_t:s0"
+content = "system_u:object_r:virt_var_lib_t:s0"
+file = "system_u:object_r:svirt_lxc_file_t:s0"

--- a/config/appconfig-standard/lxc_contexts
+++ b/config/appconfig-standard/lxc_contexts
@@ -1,0 +1,3 @@
+process = "system_u:system_r:svirt_lxc_net_t"
+content = "system_u:object_r:virt_var_lib_t"
+file = "system_u:object_r:svirt_lxc_file_t"


### PR DESCRIPTION
selinux_lxc_contexts_path() function in upstream libselinux points to
this config file. It is ATM used by libvirt.

The file from Fedora also contains sandbox_lxc_process and
sandbox_kvm_process parameters, but I cannot find where they are used,
keep them out of the file for the time being.