### PR TITLE
Allow kdevtmpfs to unlink fixed disk devices

### DIFF
--- a/policy/modules/kernel/kernel.te
+++ b/policy/modules/kernel/kernel.te
@@ -316,6 +316,7 @@ ifdef(`init_systemd',`
 		storage_dev_filetrans_fixed_disk(kernel_t)
 		storage_setattr_fixed_disk_dev(kernel_t)
 		storage_create_fixed_disk_dev(kernel_t)
+		storage_delete_fixed_disk_dev(kernel_t)
 	')
 ')
 


### PR DESCRIPTION
When a device gets removed, for example with ``cryptsetup close``,
kdevtmpfs (a kernel thread) removes its entry from devtmpfs filesystem:

    avc:  denied  { unlink } for  pid=48 comm="kdevtmpfs"
    name="dm-4" dev="devtmpfs" ino=144111
    scontext=system_u:system_r:kernel_t
    tcontext=system_u:object_r:fixed_disk_device_t tclass=blk_file

Allow this access on systems using systemd.