### PR TITLE
Adds attribute mlstrustedsocket, along with the interface.

### DIFF
--- a/policy/mls
+++ b/policy/mls
@@ -209,14 +209,16 @@ mlsconstrain unix_stream_socket connectto
 	 (( t1 == mlsnetwriteranged ) and ( l1 dom l2 ) and ( l1 domby h2 )) or
 	 (( t1 == mlsnetwritetoclr ) and ( h1 dom l2 ) and ( l1 domby l2 )) or
 	 ( t1 == mlsnetwrite ) or
-	 ( t2 == mlstrustedobject ));
+	 ( t2 == mlstrustedobject ) or
+	 ( t2 == mlstrustedsocket ));
 
 mlsconstrain unix_dgram_socket sendto
 	(( l1 eq l2 ) or 
 	 (( t1 == mlsnetwriteranged ) and ( l1 dom l2 ) and ( l1 domby h2 )) or
 	 (( t1 == mlsnetwritetoclr ) and ( h1 dom l2 ) and ( l1 domby l2 )) or
 	 ( t1 == mlsnetwrite ) or
-	 ( t2 == mlstrustedobject ));
+	 ( t2 == mlstrustedobject ) or
+	 ( t2 == mlstrustedsocket ));
 
 # these access vectors have no MLS restrictions
 # { socket tcp_socket udp_socket rawip_socket netlink_socket packet_socket key_socket unix_stream_socket unix_dgram_socket netlink_route_socket netlink_firewall_socket netlink_tcpdiag_socket netlink_nflog_socket netlink_xfrm_socket netlink_selinux_socket netlink_audit_socket netlink_ip6fw_socket netlink_dnrt_socket } { ioctl create lock append bind sendto send_msg name_bind }

--- a/policy/modules/kernel/mls.if
+++ b/policy/modules/kernel/mls.if
@@ -802,6 +802,33 @@ interface(`mls_trusted_object',`
 
 ########################################
 ## <summary>
+##	Make specified socket MLS trusted.
+## </summary>
+## <desc>
+##	<p>
+##	Make specified socket MLS trusted. For sockets
+##	marked as such, this allows all levels to:
+##	 * sendto to unix_dgram_sockets
+##	 * connectto to unix_stream_sockets
+##	respectively.
+##	</p>
+## </desc>
+## <param name="domain">
+##	<summary>
+##	The type of the object.
+##	</summary>
+## </param>
+#
+interface(`mls_trusted_socket',`
+	gen_require(`
+		attribute mlstrustedsocket;
+	')
+
+	typeattribute $1 mlstrustedsocket;
+')
+
+########################################
+## <summary>
 ##	Make the specified domain trusted
 ##	to inherit and use file descriptors
 ##	from all levels.

--- a/policy/modules/kernel/mls.te
+++ b/policy/modules/kernel/mls.te
@@ -56,6 +56,7 @@ attribute mlsdbupgrade;
 attribute mlsdbdowngrade;
 
 attribute mlstrustedobject;
+attribute mlstrustedsocket;
 
 attribute privrangetrans;
 attribute mlsrangetrans;

--- a/policy/modules/system/logging.te
+++ b/policy/modules/system/logging.te
@@ -68,6 +68,7 @@ type syslogd_t;
 type syslogd_exec_t;
 init_daemon_domain(syslogd_t, syslogd_exec_t)
 init_named_socket_activation(syslogd_t, syslogd_var_run_t)
+mls_trusted_socket(syslogd_t)
 
 type syslogd_initrc_exec_t;
 init_script_file(syslogd_initrc_exec_t)


### PR DESCRIPTION
Hi Tresys!

When building MLS policy, /dev/log socket gets created with just mls_systemhigh sensitivity (s3 in my case, build.conf in [0]), and that contradict mls constraints [1].
I don't quite like setting all of syslogd_t to mlstrustedobject, so the proposed patch does what was discussed in [this thread from 2010](http://oss.tresys.com/pipermail/refpolicy/2010-November/003444.html).
Is this the right direction, or i'm missing something obvious here and should fix that elsewhere?

I didn't touch the "mlsconstrain unix_stream_socket connectto" one, since i haven't seen it in logs yet.


[0] build.conf for reference
```shell
TYPE = mls
NAME = custom
DISTRO = debian
UNK_PERMS = reject
DIRECT_INITRC = n
MONOLITHIC = n
UBAC = y
CUSTOM_BUILDOPT =
MLS_SENS = 4
MLS_CATS = 32
MCS_CATS = 32
QUIET = n
```
[1] sample avc, audit2allow explanation and sesearch.
```shell
root/system_r@testvm:/tmp # grep sendto /var/log/audit/audit.log | tail -1
type=AVC msg=audit(1459979237.878:95): avc:  denied  { sendto } for  pid=1914 comm="login" path="/dev/log" scontext=system_u:system_r:local_login_t:s0-s3:c0.c31 tcontext=system_u:system_r:syslogd_t:s3:c0.c31 tclass=unix_dgram_socket permissive=1
root/system_r@testvm:/tmp # grep sendto /var/log/audit/audit.log | tail -1 | audit2allow -ve 


#============= local_login_t ==============
# audit(1459979237.878:95):
#  scontext="system_u:system_r:local_login_t:s0-s3:c0.c31" tcontext="system_u:system_r:syslogd_t:s3:c0.c31"
#  class="unix_dgram_socket" perms="sendto"
#  comm="login" exe="" path=""
#  message="type=AVC msg=audit(1459979237.878:95): avc:  denied  { sendto } for
#   pid=1914 comm="login" path="/dev/log"
#   scontext=system_u:system_r:local_login_t:s0-s3:c0.c31
#   tcontext=system_u:system_r:syslogd_t:s3:c0.c31 tclass=unix_dgram_socket
#   permissive=1 "
#!!!! This avc is a constraint violation.  You would need to modify the attributes of either the source or target types to allow this access.
#Constraint rule: 
        mlsconstrain unix_dgram_socket { sendto } ((l1 eq l2 -Fail-)  or (t1 == mlsnetwriteranged -Fail-)  and (l1 dom l2 -Fail-)  and (l1 domby h2)  or (t1 == mlsnetwritetoclr -Fail-)  and (h1 dom l2)  and (l1 domby l2)  or (t1 == mlsnetwrite -Fail-)  or (t2 == mlstrustedobject -Fail-) ); Constraint DENIED

#       Possible cause is the source level (s0-s3:c0.c31) and target level (s3:c0.c31) are different.
allow local_login_t syslogd_t:unix_dgram_socket sendto;
root/system_r@testvm:/tmp # sesearch --allow -s local_login_t -t syslogd_t -p sendto
Found 1 semantic av rules:
   allow local_login_t syslogd_t : unix_dgram_socket sendto ; 
```