### PR TITLE
update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 
 language: generic
 
+matrix:
+  fast_finish: true
+
 env:
   - TYPE=standard DISTRO=redhat MONOLITHIC=y SYSTEMD=y
   - TYPE=standard DISTRO=redhat MONOLITHIC=n SYSTEMD=y
@@ -23,7 +26,8 @@ env:
   - TYPE=mls DISTRO=gentoo MONOLITHIC=n SYSTEMD=n
 
 # Uncomment to use Travis-CI container infrastructure (https://docs.travis-ci.com/user/ci-environment/)
-#sudo: false
+sudo: false
+#dist: trusty  # libustr-dev not whitelisted for trusty
 
 # Uncomment these two lines to use Travis-CI Trusty Beta environment
 #sudo: required
@@ -42,14 +46,17 @@ addons:
     - libpcre3-dev
     - swig
 
-install:
+before_install:
   - lsb_release -a
   - bison -V
   - flex -V
+  - swig -version
+  - python -V
 
+install:
   # Download current SELinux userspace tools and libraries
-  - curl -sS -L https://github.com/SELinuxProject/selinux/archive/20160223.tar.gz | tar xz
-  - mv selinux-20160223 selinux-src
+  - curl -sS -L https://github.com/SELinuxProject/selinux/archive/20161014.tar.gz | tar xz
+  - mv selinux-20161014 selinux-src
 
   # Ubuntu 12.04 coreutils is too old to provide "ln --relative" :(
   - sed 's/ln -sf --relative /ln -sf /' -i selinux-src/libsepol/src/Makefile
@@ -70,16 +77,16 @@ install:
   # Compile and install SELinux toolchain into ~/selinux
   # On Ubuntu 12.04, default CFLAGS make the build fail in libsepol/cil with:
   #    error: declaration of 'index' shadows a global declarationo
-  - make "DESTDIR=$HOME/selinux" CFLAGS="-O2 -pipe -fPIC -Wall -I$HOME/selinux/usr/include" -C selinux-src install
+  - make "DESTDIR=$TRAVIS_BUILD_DIR/selinux" CFLAGS="-O2 -Wall" -C selinux-src install
 
   # Use TEST_TOOLCHAIN variable to tell refpolicy Makefile about the installed location
-  - export TEST_TOOLCHAIN="$HOME/selinux"
+  - export TEST_TOOLCHAIN="$TRAVIS_BUILD_DIR/selinux"
 
   # Drop build.conf settings to listen to env vars
   - sed -r -i -e '/(MONOLITHIC|TYPE|DISTRO|SYSTEMD)/d' build.conf
 
 script:
-  - echo $TYPE $DISTRO $MONOLITHIC
+  - echo $TYPE $DISTRO $MONOLITHIC $SYSTEMD
   - make bare
   - make conf
   - make


### PR DESCRIPTION
- set travis option matrix: fast_finish: true
- explicit enable container infrastructure and add comment why trusty is not working
- use recent version of SELinux userspace tools and libraries
- move installdir of SELinux userspace tools and libraries from $HOME to the more stable $TRAVIS_BUILD_DIR
- remove some unneeded compiler flags