### PR TITLE
add method to declare modules as required for a specific set of distributions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,7 @@ endif
 # enable distribution-specific policy
 ifneq ($(DISTRO),)
 	M4PARAM += -D distro_$(DISTRO)
+	gendoc += -D $(DISTRO)
 endif
 
 ifeq "$(DISTRO)" "ubuntu"

--- a/doc/policy.dtd
+++ b/doc/policy.dtd
@@ -5,12 +5,12 @@
 <!ATTLIST layer
       name CDATA #REQUIRED>
 <!ELEMENT module (summary,desc?,required?,(interface|template)*,(bool|tunable)*)>
-<!ATTLIST module 
+<!ATTLIST module
       name CDATA #REQUIRED
       filename CDATA #REQUIRED>
 <!ELEMENT required (#PCDATA)>
 <!ATTLIST required
-      val (true|false) "false">
+      val CDATA #REQUIRED>
 <!ELEMENT tunable (desc)>
 <!ATTLIST tunable
       name CDATA #REQUIRED
@@ -26,12 +26,12 @@
 <!ATTLIST template name CDATA #REQUIRED lineno CDATA #REQUIRED>
 <!ELEMENT desc (#PCDATA|%inline.class;)*>
 <!ELEMENT param (summary)>
-<!ATTLIST param 
+<!ATTLIST param
       name CDATA #REQUIRED
       optional (true|false) "false"
       unused (true|false) "false">
 <!ELEMENT infoflow EMPTY>
-<!ATTLIST infoflow 
+<!ATTLIST infoflow
       type CDATA #REQUIRED
       weight CDATA #IMPLIED>
 <!ELEMENT rolebase EMPTY>

--- a/policy/modules/kernel/storage.if
+++ b/policy/modules/kernel/storage.if
@@ -1,4 +1,5 @@
 ## <summary>Policy controlling access to storage devices</summary>
+## <required val="debian," />
 
 ########################################
 ## <summary>

--- a/policy/modules/roles/staff.if
+++ b/policy/modules/roles/staff.if
@@ -1,4 +1,5 @@
 ## <summary>Administrator's unprivileged user role</summary>
+## <required val="debian," />
 
 ########################################
 ## <summary>

--- a/policy/modules/roles/sysadm.if
+++ b/policy/modules/roles/sysadm.if
@@ -1,4 +1,5 @@
 ## <summary>General system administration role</summary>
+## <required val="debian," />
 
 ########################################
 ## <summary>

--- a/policy/modules/roles/unprivuser.if
+++ b/policy/modules/roles/unprivuser.if
@@ -1,4 +1,5 @@
 ## <summary>Generic unprivileged user role</summary>
+## <required val="debian," />
 
 ########################################
 ## <summary>

--- a/policy/modules/system/application.if
+++ b/policy/modules/system/application.if
@@ -1,4 +1,5 @@
 ## <summary>Policy for user executable applications.</summary>
+## <required val="debian," />
 
 ########################################
 ## <summary>

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -1,4 +1,5 @@
 ## <summary>Common policy for authentication and user login.</summary>
+## <required val="debian," />
 
 ########################################
 ## <summary>

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -1,4 +1,5 @@
 ## <summary>System initialization programs (init and init scripts).</summary>
+## <required val="debian," />
 
 ########################################
 ## <summary>

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -272,8 +272,6 @@ ifdef(`init_systemd',`
 
 	term_relabel_pty_dirs(init_t)
 
-	clock_read_adjtime(init_t)
-
 	logging_manage_pid_sockets(init_t)
 	logging_send_audit_msgs(init_t)
 	logging_relabelto_devlog_sock_files(init_t)
@@ -286,6 +284,10 @@ ifdef(`init_systemd',`
 	optional_policy(`
 		systemd_relabelto_kmod_files(init_t)
 		systemd_dbus_chat_logind(init_t)
+	')
+
+	optional_policy(`
+		clock_read_adjtime(init_t)
 	')
 
 	optional_policy(`

--- a/policy/modules/system/libraries.if
+++ b/policy/modules/system/libraries.if
@@ -1,4 +1,5 @@
 ## <summary>Policy for system libraries.</summary>
+## <required val="debian," />
 
 ########################################
 ## <summary>

--- a/policy/modules/system/locallogin.if
+++ b/policy/modules/system/locallogin.if
@@ -1,4 +1,5 @@
 ## <summary>Policy for local logins.</summary>
+## <required val="debian," />
 
 ########################################
 ## <summary>

--- a/policy/modules/system/logging.if
+++ b/policy/modules/system/logging.if
@@ -1,4 +1,5 @@
 ## <summary>Policy for the kernel message logger and system logging daemon.</summary>
+## <required val="debian," />
 
 ########################################
 ## <summary>
@@ -8,7 +9,7 @@
 ## <desc>
 ##	<p>
 ##	Make the specified type usable for log files in a filesystem.
-##	This will also make the type usable for files, making 
+##	This will also make the type usable for files, making
 ##	calls to files_type() redundant.  Failure to use this interface
 ##	for a log file type may result in problems with log
 ##	rotation, log analysis, and log monitoring programs.

--- a/policy/modules/system/miscfiles.if
+++ b/policy/modules/system/miscfiles.if
@@ -1,4 +1,5 @@
 ## <summary>Miscellaneous files.</summary>
+## <required val="debian," />
 
 ########################################
 ## <summary>

--- a/policy/modules/system/modutils.if
+++ b/policy/modules/system/modutils.if
@@ -1,4 +1,5 @@
 ## <summary>Policy for kernel module utilities</summary>
+## <required val="debian," />
 
 ######################################
 ## <summary>

--- a/policy/modules/system/selinuxutil.if
+++ b/policy/modules/system/selinuxutil.if
@@ -1,4 +1,5 @@
 ## <summary>Policy for SELinux policy and userland applications.</summary>
+## <required val="debian," />
 
 #######################################
 ## <summary>

--- a/policy/modules/system/sysnetwork.if
+++ b/policy/modules/system/sysnetwork.if
@@ -1,4 +1,5 @@
 ## <summary>Policy for network configuration: ifconfig and dhcp client.</summary>
+## <required val="debian," />
 
 #######################################
 ## <summary>

--- a/policy/modules/system/systemd.if
+++ b/policy/modules/system/systemd.if
@@ -1,4 +1,5 @@
 ## <summary>Systemd components (not PID 1)</summary>
+## <required val="debian," />
 
 ######################################
 ## <summary>

--- a/policy/modules/system/udev.if
+++ b/policy/modules/system/udev.if
@@ -1,4 +1,5 @@
 ## <summary>Policy for udev.</summary>
+## <required val="debian," />
 
 ########################################
 ## <summary>

--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -1,4 +1,5 @@
 ## <summary>Policy for user domains</summary>
+## <required val="debian," />
 
 #######################################
 ## <summary>
@@ -778,7 +779,7 @@ template(`userdom_common_user_template',`
 		virt_home_filetrans_virt_home($1_t, dir, ".virtinst")
 		virt_home_filetrans_virt_content($1_t, dir, "isos")
 		virt_home_filetrans_svirt_home($1_t, dir, "qemu")
-		virt_home_filetrans_virt_home($1_t, dir, "VirtualMachines")	
+		virt_home_filetrans_virt_home($1_t, dir, "VirtualMachines")
 	')
 ')
 

--- a/support/sedoctool.py
+++ b/support/sedoctool.py
@@ -9,16 +9,15 @@
 #      the Free Software Foundation, version 2.
 
 """
-	This module generates configuration files and documentation from the 
-	SELinux reference policy XML format. 
+	This module generates configuration files and documentation from the
+	SELinux reference policy XML format.
 """
 
 import sys
 import getopt
 import pyplate
 import os
-import string
-from xml.dom.minidom import parse, parseString
+from xml.dom.minidom import parseString
 
 #modules enabled and disabled values
 MOD_BASE = "base"
@@ -46,11 +45,11 @@ def read_policy_xml(filename):
 
 	try:
 		doc = parseString(xml_fh.read())
-	except: 
+	except:
 		xml_fh.close()
 		error("Error while parsing xml")
 
-	xml_fh.close()	
+	xml_fh.close()
 	return doc
 
 def gen_booleans_conf(doc, file_name, namevalue_list):
@@ -108,7 +107,7 @@ def gen_booleans_conf(doc, file_name, namevalue_list):
 				file_name.write("%s = %s\n\n" % (bool_name, bool_val))
 				bool_name = bool_val = None
 
-def gen_module_conf(doc, file_name, namevalue_list):
+def gen_module_conf(doc, file_name, namevalue_list, distro):
 	"""
 	Generates the module configuration file using the XML provided and the
 	previous module configuration.
@@ -134,6 +133,12 @@ def gen_module_conf(doc, file_name, namevalue_list):
 				if req.getAttribute("val") == "true":
 					mod_req = True
 
+				# check for distro specific settings
+				if distro:
+					for attr in req.getAttribute("val").split(','):
+						if attr == distro:
+							mod_req = True
+
 			# Skip if we arnt working on the right set of modules.
 			if mod_req and not required or not mod_req and required:
 				continue
@@ -141,7 +146,7 @@ def gen_module_conf(doc, file_name, namevalue_list):
 
 			mod_name = mod_layer = None
 
-			mod_name = node.getAttribute("name")	
+			mod_name = node.getAttribute("name")
 			mod_layer = node.parentNode.getAttribute("name")
 
 			if mod_name and mod_layer:
@@ -171,7 +176,7 @@ def gen_module_conf(doc, file_name, namevalue_list):
 					# Set the module to base if it is marked as required.
 					if mod_req:
 						file_name.write("%s = %s\n\n" % (mod_name, MOD_BASE))
-					# Set the module to enabled if it is not required. 
+					# Set the module to enabled if it is not required.
 					else:
 						file_name.write("%s = %s\n\n" % (mod_name, MOD_ENABLED))
 
@@ -222,7 +227,7 @@ def int_cmp_func(a):
 	"""
 
 	return a["interface_name"]
-		
+
 def temp_cmp_func(a):
 	"""
 	Return the template name to sort/compare on.
@@ -295,7 +300,7 @@ def format_txt_desc(node):
 			desc_buf += desc.data + "\n"
 		elif desc.nodeName == "p":
 			desc_buf += desc.firstChild.data + "\n"
-			for chld in desc.childNodes: 
+			for chld in desc.childNodes:
 				if chld.nodeName == "ul":
 					desc_buf += "\n"
 					for li in chld.getElementsByTagName("li"):
@@ -303,7 +308,7 @@ def format_txt_desc(node):
 
 	return desc_buf.strip() + "\n"
 
-def gen_docs(doc, working_dir, templatedir):
+def gen_docs(doc, working_dir, templatedir, distro):
 	"""
 	Generates all the documentation.
 	"""
@@ -359,7 +364,7 @@ def gen_docs(doc, working_dir, templatedir):
 	try:
 		os.chdir(working_dir)
 	except:
-		error("Could not chdir to target directory")	
+		error("Could not chdir to target directory")
 
 
 #arg, i have to go through this dom tree ahead of time to build up the menus
@@ -401,12 +406,12 @@ def gen_docs(doc, working_dir, templatedir):
 
 		body_args = { "menu" : menu_buf,
 			      "content" : content_buf }
-	
+
 		index_file = mod_layer + ".html"
 		index_fh = open(index_file, "w")
 		body_tpl = pyplate.Template(bodydata)
 		body_tpl.execute(index_fh, body_args)
-		index_fh.close()	
+		index_fh.close()
 
 	menu = gen_doc_menu(None, module_list)
 	menu_args = { "menulist" : menu,
@@ -438,6 +443,12 @@ def gen_docs(doc, working_dir, templatedir):
 		for req in node.getElementsByTagName("required"):
 			if req.getAttribute("val") == "true":
 				mod_req = True
+
+			# check for distro specific settings
+			if distro:
+				for attr in req.getAttribute("val").split(','):
+					if attr == distro:
+						mod_req = True
 
 		for desc in node.getElementsByTagName("summary"):
 			if desc.parentNode == node:
@@ -486,10 +497,10 @@ def gen_docs(doc, working_dir, templatedir):
 					   "interface_parameters" : interface_parameters,
 					   "mod_name": mod_name,
 					   "mod_layer" : mod_layer })
-		interfaces.sort(key=int_cmp_func)	
+		interfaces.sort(key=int_cmp_func)
 		interface_tpl = pyplate.Template(intdata)
 		interface_buf = interface_tpl.execute_string({"interfaces" : interfaces})
-	
+
 
 # now generate individual template pages
 		templates = []
@@ -533,7 +544,7 @@ def gen_docs(doc, working_dir, templatedir):
 					   "mod_name": mod_name,
 					   "mod_layer" : mod_layer })
 
-		templates.sort(key=temp_cmp_func)	
+		templates.sort(key=temp_cmp_func)
 		template_tpl = pyplate.Template(templatedata)
 		template_buf = template_tpl.execute_string({"templates" : templates})
 
@@ -584,7 +595,7 @@ def gen_docs(doc, working_dir, templatedir):
 		tunables.sort(key=tun_cmp_func)
 		tunable_tpl = pyplate.Template(tundata)
 		tunable_buf = tunable_tpl.execute_string({"tunables" : tunables})
-	
+
 
 		menu = gen_doc_menu(mod_layer, module_list)
 
@@ -611,7 +622,7 @@ def gen_docs(doc, working_dir, templatedir):
 			boolean_buf = None
 
 		module_args = { "mod_layer" : mod_layer,
-			      "mod_name" : mod_name,	
+			      "mod_name" : mod_name,
 			      "mod_summary" : mod_summary,
 			      "mod_desc" : mod_desc,
 			      "mod_req" : mod_req,
@@ -625,20 +636,20 @@ def gen_docs(doc, working_dir, templatedir):
 
 		body_args = { "menu" : menu_buf,
 			      "content" : module_buf }
-			  
+
 		module_file = mod_layer + "_" + mod_name + ".html"
 		module_fh = open(module_file, "w")
 		body_tpl = pyplate.Template(bodydata)
 		body_tpl.execute(module_fh, body_args)
 		module_fh.close()
 
-		
+
 	menu = gen_doc_menu(None, module_list)
 	menu_args = { "menulist" : menu,
 		      "mod_layer" : None }
 	menu_tpl = pyplate.Template(menudata)
 	menu_buf = menu_tpl.execute_string(menu_args)
-	
+
 	#build the interface index
 	all_interfaces.sort(key=int_cmp_func)
 	interface_tpl = pyplate.Template(intlistdata)
@@ -647,7 +658,7 @@ def gen_docs(doc, working_dir, templatedir):
 	int_fh = open(int_file, "w")
 	body_tpl = pyplate.Template(bodydata)
 
-	body_args = { "menu" : menu_buf, 
+	body_args = { "menu" : menu_buf,
 		      "content" : interface_buf }
 
 	body_tpl.execute(int_fh, body_args)
@@ -662,7 +673,7 @@ def gen_docs(doc, working_dir, templatedir):
 	temp_fh = open(temp_file, "w")
 	body_tpl = pyplate.Template(bodydata)
 
-	body_args = { "menu" : menu_buf, 
+	body_args = { "menu" : menu_buf,
 		      "content" : template_buf }
 
 	body_tpl.execute(temp_fh, body_args)
@@ -702,7 +713,7 @@ def gen_docs(doc, working_dir, templatedir):
 	temp_fh = open(temp_file, "w")
 	body_tpl = pyplate.Template(bodydata)
 
-	body_args = { "menu" : menu_buf, 
+	body_args = { "menu" : menu_buf,
 		      "content" : tunable_buf }
 
 	body_tpl.execute(temp_fh, body_args)
@@ -731,7 +742,7 @@ def gen_docs(doc, working_dir, templatedir):
 
 	body_tpl.execute(global_bool_fh, body_args)
 	global_bool_fh.close()
-	
+
 	#build the boolean index
 	all_booleans = all_booleans + global_bool
 	all_booleans.sort(key=bool_cmp_func)
@@ -741,7 +752,7 @@ def gen_docs(doc, working_dir, templatedir):
 	temp_fh = open(temp_file, "w")
 	body_tpl = pyplate.Template(bodydata)
 
-	body_args = { "menu" : menu_buf, 
+	body_args = { "menu" : menu_buf,
 		      "content" : boolean_buf }
 
 	body_tpl.execute(temp_fh, body_args)
@@ -749,13 +760,13 @@ def gen_docs(doc, working_dir, templatedir):
 
 
 
-def error(error):
+def error(msg):
 	"""
 	Print an error message and exit.
 	"""
 
 	sys.stderr.write("%s exiting for: " % sys.argv[0])
-	sys.stderr.write("%s\n" % error)
+	sys.stderr.write("%s\n" % msg)
 	sys.stderr.flush()
 	sys.exit(1)
 
@@ -779,16 +790,17 @@ def usage():
 	sys.stdout.write("-d --docs <dir>		--	write interface documentation to <dir>\n")
 	sys.stdout.write("-x --xml <file>		--	filename to read xml data from\n")
 	sys.stdout.write("-T --templates <dir>		--	template directory for documents\n")
+	sys.stdout.write("-D --distro <disto_name>	--	generate configuration specific for distro <disto_name>\n")
 
 
 # MAIN PROGRAM
 try:
-	opts, args = getopt.getopt(sys.argv[1:], "b:m:d:x:T:", ["booleans","modules","docs","xml", "templates"])
+	opts, args = getopt.getopt(sys.argv[1:], "b:m:d:x:T:D:", ["booleans","modules","docs","xml", "templates", "distro"])
 except getopt.GetoptError:
 	usage()
 	sys.exit(1)
 
-booleans = modules = docsdir = None
+booleans = modules = docsdir = distro = None
 templatedir = "templates/"
 xmlfile = "policy.xml"
 
@@ -803,9 +815,11 @@ for opt, val in opts:
 		xmlfile = val
 	if opt in ("-T", "--templates"):
 		templatedir = val
+	if opt in ("-D", "--distro"):
+		distro = val
 
 doc = read_policy_xml(xmlfile)
-		
+
 if booleans:
 	namevalue_list = []
 	if os.path.exists(booleans):
@@ -834,15 +848,15 @@ if modules:
 			conf = open(modules, 'r')
 		except:
 			error("Could not open modules file for reading")
-		namevalue_list = get_conf(conf)	
+		namevalue_list = get_conf(conf)
 		conf.close()
 
 	try:
 		conf = open(modules, 'w')
 	except:
 		error("Could not open modules file for writing")
-	gen_module_conf(doc, conf, namevalue_list)
+	gen_module_conf(doc, conf, namevalue_list, distro)
 	conf.close()
 
-if docsdir: 
-	gen_docs(doc, docsdir, templatedir)
+if docsdir:
+	gen_docs(doc, docsdir, templatedir, distro)


### PR DESCRIPTION
Currently in the non-monolithic build modules are compiled into the base module when their interface file contains a xml element `required` with the attribute `val` and the value `true`. This setting is determined for all configurations and for all distributions.

This patch adds an options to configure a module as basemodule for a specific distribution (using the build.conf variable DISTRO) by defining the value `val` as a comma separated list of distributions, like `<required val="debian" />` or `<required val="debian,gentoo" />`.

Also this patch sets this option on several modules for debian.

clock_read_adjtime(init_t) is moved into optional block to keep module clock non-base