### PR TITLE
fix userdomain dependency on xserver

### DIFF
--- a/policy/modules/system/userdomain.if
+++ b/policy/modules/system/userdomain.if
@@ -778,7 +778,7 @@ template(`userdom_common_user_template',`
 		virt_home_filetrans_virt_home($1_t, dir, ".virtinst")
 		virt_home_filetrans_virt_content($1_t, dir, "isos")
 		virt_home_filetrans_svirt_home($1_t, dir, "qemu")
-		virt_home_filetrans_virt_home($1_t, dir, "VirtualMachines")	
+		virt_home_filetrans_virt_home($1_t, dir, "VirtualMachines")
 	')
 ')
 
@@ -983,8 +983,6 @@ template(`userdom_restricted_xwindows_user_template',`
 	logging_send_audit_msgs($1_t)
 	selinux_get_enforce_mode($1_t)
 
-	xserver_restricted_role($1_r, $1_t)
-
 	optional_policy(`
 		alsa_read_config($1_t)
 	')
@@ -1017,6 +1015,10 @@ template(`userdom_restricted_xwindows_user_template',`
 
 	optional_policy(`
 		setroubleshoot_dontaudit_stream_connect($1_t)
+	')
+
+	optional_policy(`
+		xserver_restricted_role($1_r, $1_t)
 	')
 ')
 


### PR DESCRIPTION
Probably one would have the module xserver installed when installing modules like xguest or mozilla, but when not ugly error messages come up:

Failed to resolve booleanif statement at /var/lib/selinux/default/tmp/modules/400/xguest/cil:662
semodule:  Failed!