### PR TITLE
allow dhcp_t to domtrans into avahi

### DIFF
--- a/policy/modules/system/sysnetwork.te
+++ b/policy/modules/system/sysnetwork.te
@@ -171,6 +171,10 @@ ifdef(`init_systemd',`
 ')
 
 optional_policy(`
+	avahi_domtrans(dhcpc_t)
+')
+
+optional_policy(`
 	consoletype_run(dhcpc_t, dhcpc_roles)
 ')
 


### PR DESCRIPTION
```
#============= dhcpc_t ==============
# audit(1459860992.664:6):
#  scontext="system_u:system_r:dhcpc_t:s0" tcontext="system_u:object_r:avahi_exec_t:s0"
#  class="file" perms="execute_no_trans"
#  comm="dhclient-script" exe="" path=""
#  message="/var/log/syslog.2.gz:Apr  5 14:56:32 debianSe kernel: [    4.830761]
#   audit: type=1400 audit(1459860992.664:6): avc:  denied  { execute_no_trans }
#   for  pid=412 comm="dhclient-script" path="/usr/sbin/avahi-autoipd" dev="sda1"
#   ino=140521 scontext=system_u:system_r:dhcpc_t:s0
#   tcontext=system_u:object_r:avahi_exec_t:s0 tclass=file permissive=1 "
# audit(1454514879.616:134):
#  scontext="system_u:system_r:dhcpc_t:s0" tcontext="system_u:object_r:avahi_exec_t:s0"
#  class="file" perms="execute_no_trans"
#  comm="dhclient-script" exe="" path=""
#  message="/var/log/syslog.5.gz:Feb  3 16:54:39 debianSe kernel: [   13.237496]
#   audit: type=1400 audit(1454514879.616:134): avc:  denied  { execute_no_trans
#   } for  pid=464 comm="dhclient-script" path="/usr/sbin/avahi-autoipd"
#   dev="sda1" ino=140521 scontext=system_u:system_r:dhcpc_t
#   tcontext=system_u:object_r:avahi_exec_t tclass=file permissive=1 "
allow dhcpc_t avahi_exec_t:file execute_no_trans;
# audit(1459860992.660:4):
#  scontext="system_u:system_r:dhcpc_t:s0" tcontext="system_u:object_r:avahi_exec_t:s0"
#  class="file" perms="execute"
#  comm="dhclient-script" exe="" path=""
#  message="/var/log/syslog.2.gz:Apr  5 14:56:32 debianSe kernel: [    4.827312]
#   audit: type=1400 audit(1459860992.660:4): avc:  denied  { execute } for
#   pid=412 comm="dhclient-script" name="avahi-autoipd" dev="sda1" ino=140521
#   scontext=system_u:system_r:dhcpc_t:s0
#   tcontext=system_u:object_r:avahi_exec_t:s0 tclass=file permissive=1 "
# audit(1459860992.664:5):
#  scontext="system_u:system_r:dhcpc_t:s0" tcontext="system_u:object_r:avahi_exec_t:s0"
#  class="file" perms="{ read open }"
#  comm="dhclient-script" exe="" path=""
#  message="/var/log/syslog.2.gz:Apr  5 14:56:32 debianSe kernel: [    4.829009]
#   audit: type=1400 audit(1459860992.664:5): avc:  denied  { read open } for
#   pid=412 comm="dhclient-script" path="/usr/sbin/avahi-autoipd" dev="sda1"
#   ino=140521 scontext=system_u:system_r:dhcpc_t:s0
#   tcontext=system_u:object_r:avahi_exec_t:s0 tclass=file permissive=1 "
# audit(1454514879.616:132):
#  scontext="system_u:system_r:dhcpc_t:s0" tcontext="system_u:object_r:avahi_exec_t:s0"
#  class="file" perms="execute"
#  comm="dhclient-script" exe="" path=""
#  message="/var/log/syslog.5.gz:Feb  3 16:54:39 debianSe kernel: [   13.237297]
#   audit: type=1400 audit(1454514879.616:132): avc:  denied  { execute } for
#   pid=464 comm="dhclient-script" name="avahi-autoipd" dev="sda1" ino=140521
#   scontext=system_u:system_r:dhcpc_t tcontext=system_u:object_r:avahi_exec_t
#   tclass=file permissive=1 "
# audit(1454514879.616:133):
#  scontext="system_u:system_r:dhcpc_t:s0" tcontext="system_u:object_r:avahi_exec_t:s0"
#  class="file" perms="{ read open }"
#  comm="dhclient-script" exe="" path=""
#  message="/var/log/syslog.5.gz:Feb  3 16:54:39 debianSe kernel: [   13.237309]
#   audit: type=1400 audit(1454514879.616:133): avc:  denied  { read open } for
#   pid=464 comm="dhclient-script" path="/usr/sbin/avahi-autoipd" dev="sda1"
#   ino=140521 scontext=system_u:system_r:dhcpc_t
#   tcontext=system_u:object_r:avahi_exec_t tclass=file permissive=1 "
#!!!! This avc is allowed in the current policy
allow dhcpc_t avahi_exec_t:file { read execute open };
```