### PR TITLE
allow semanage to search /var/lib/selinux

### DIFF
--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -448,6 +448,8 @@ allow semanage_t self:fifo_file rw_fifo_file_perms;
 
 allow semanage_t policy_config_t:file rw_file_perms;
 
+allow semanage_t policy_src_t:dir search_dir_perms;
+
 filetrans_pattern(semanage_t, selinux_config_t, semanage_store_t, dir, "modules")
 
 allow semanage_t semanage_tmp_t:dir manage_dir_perms;


### PR DESCRIPTION
```
#============= semanage_t ==============
# audit(1459434871.036:993):
#  scontext="unconfined_u:unconfined_r:semanage_t:s0-s0:c0.c1023" tcontext="system_u:object_r:policy_src_t:s0"
#  class="dir" perms="search"
#  comm="semodule" exe="" path=""
#  message="Mar 31 16:34:31 debianSe kernel: [ 6205.083415] audit: type=1400
#   audit(1459434871.036:993): avc:  denied  { search } for  pid=8090
#   comm="semodule" name="selinux" dev="sda1" ino=142515
#   scontext=unconfined_u:unconfined_r:semanage_t:s0-s0:c0.c1023
#   tcontext=system_u:object_r:policy_src_t:s0 tclass=dir permissive=0 "
allow semanage_t policy_src_t:dir search;
```