### PR TITLE
setfiles: allow getattr to kernel pseudo fs

### DIFF
--- a/policy/modules/kernel/filesystem.if
+++ b/policy/modules/kernel/filesystem.if
@@ -3420,9 +3420,29 @@ interface(`fs_read_nsfs_files',`
 
 	allow $1 nsfs_t:file read_file_perms;
 ')
+
 ########################################
 ## <summary>
-##	Getattr on pstore dirs.
+##	Get the attributes of a pstore filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_getattr_pstorefs',`
+	gen_require(`
+		type pstore_t;
+	')
+
+	allow $1 pstore_t:filesystem getattr;
+')
+
+########################################
+## <summary>
+##	Get the attributes of directories
+##	of a pstore filesystem.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -4580,6 +4600,43 @@ interface(`fs_manage_tmpfs_blk_files',`
 	')
 
 	manage_blk_files_pattern($1, tmpfs_t, tmpfs_t)
+')
+
+########################################
+## <summary>
+##	Get the attributes of a trace filesystem.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`fs_getattr_tracefs',`
+	gen_require(`
+		type tracefs_t;
+	')
+
+        allow $1 tracefs_t:filesystem getattr;
+')
+
+########################################
+## <summary>
+##      Get the attributes of files
+##	on a trace filesystem.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`fs_getattr_tracefs_files',`
+	gen_require(`
+		type tracefs_t;
+	')
+
+        allow $1 tracefs_t:file getattr;
 ')
 
 ########################################

--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -324,14 +324,17 @@ allow restorecond_t self:fifo_file rw_fifo_file_perms;
 allow restorecond_t restorecond_var_run_t:file manage_file_perms;
 files_pid_filetrans(restorecond_t, restorecond_var_run_t, file)
 
-kernel_use_fds(restorecond_t)
-kernel_rw_pipes(restorecond_t)
+kernel_getattr_debugfs(restorecond_t)
 kernel_read_system_state(restorecond_t)
+kernel_rw_pipes(restorecond_t)
+kernel_use_fds(restorecond_t)
 
-fs_relabelfrom_noxattr_fs(restorecond_t)
 fs_dontaudit_list_nfs(restorecond_t)
 fs_getattr_all_xattr_fs(restorecond_t)
+fs_getattr_pstore_dirs(restorecond_t)
+fs_getattr_tracefs(restorecond_t)
 fs_list_inotifyfs(restorecond_t)
+fs_relabelfrom_noxattr_fs(restorecond_t)
 
 selinux_validate_context(restorecond_t)
 selinux_compute_access_vector(restorecond_t)
@@ -540,6 +543,7 @@ kernel_rw_pipes(setfiles_t)
 kernel_rw_unix_dgram_sockets(setfiles_t)
 kernel_dontaudit_list_all_proc(setfiles_t)
 kernel_dontaudit_list_all_sysctls(setfiles_t)
+kernel_getattr_debugfs(setfiles_t)
 
 dev_relabel_all_dev_nodes(setfiles_t)
 # to handle when /dev/console needs to be relabeled
@@ -556,9 +560,13 @@ files_read_usr_symlinks(setfiles_t)
 files_dontaudit_read_all_symlinks(setfiles_t)
 
 fs_getattr_all_xattr_fs(setfiles_t)
+fs_getattr_pstore_dirs(setfiles_t)
+fs_getattr_pstorefs(setfiles_t)
+fs_getattr_tracefs(setfiles_t)
+fs_getattr_tracefs_files(setfiles_t)
 fs_list_all(setfiles_t)
-fs_search_auto_mountpoints(setfiles_t)
 fs_relabelfrom_noxattr_fs(setfiles_t)
+fs_search_auto_mountpoints(setfiles_t)
 
 mls_file_read_all_levels(setfiles_t)
 mls_file_write_all_levels(setfiles_t)


### PR DESCRIPTION
userdomain should not edit labels of kernel pseudo filesystems, but allow setfiles/restorecon(d) to check the contexts for correctness