### PR TITLE
/run/utmp: label as utmp_t

### DIFF
--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -228,6 +228,7 @@ template(`ssh_server_template', `
 
 	auth_rw_login_records($1_t)
 	auth_rw_faillog($1_t)
+	auth_rw_utmp($1_t)
 
 	corecmd_read_bin_symlinks($1_t)
 	corecmd_getattr_bin_files($1_t)

--- a/policy/modules/system/authlogin.fc
+++ b/policy/modules/system/authlogin.fc
@@ -1,4 +1,3 @@
-
 /bin/login		--	gen_context(system_u:object_r:login_exec_t,s0)
 
 /etc/\.pwd\.lock	--	gen_context(system_u:object_r:shadow_t,s0)
@@ -7,11 +6,20 @@
 /etc/passwd\.lock	--	gen_context(system_u:object_r:shadow_t,s0)
 /etc/shadow.*		--	gen_context(system_u:object_r:shadow_t,s0)
 
+/run/console(/.*)?	 	gen_context(system_u:object_r:pam_var_console_t,s0)
+/run/faillock(/.*)?		gen_context(system_u:object_r:faillog_t,s0)
+/run/pam_mount(/.*)?		gen_context(system_u:object_r:pam_var_run_t,s0)
+/run/pam_ssh(/.*)?		gen_context(system_u:object_r:var_auth_t,s0)
+/run/sepermit(/.*)? 		gen_context(system_u:object_r:pam_var_run_t,s0)
+/run/sudo(/.*)?			gen_context(system_u:object_r:pam_var_run_t,s0)
+/run/utmp		--	gen_context(system_u:object_r:utmp_t,s0)
+
 /sbin/pam_console_apply	 --	gen_context(system_u:object_r:pam_console_exec_t,s0)
 /sbin/pam_timestamp_check --	gen_context(system_u:object_r:pam_exec_t,s0)
 /sbin/unix_chkpwd	--	gen_context(system_u:object_r:chkpwd_exec_t,s0)
 /sbin/unix_update	--	gen_context(system_u:object_r:updpwd_exec_t,s0)
 /sbin/unix_verify	--	gen_context(system_u:object_r:chkpwd_exec_t,s0)
+
 ifdef(`distro_suse', `
 /sbin/unix2_chkpwd	--	gen_context(system_u:object_r:chkpwd_exec_t,s0)
 ')
@@ -45,11 +53,5 @@ ifdef(`distro_suse', `
 /var/log/tallylog	--	gen_context(system_u:object_r:faillog_t,s0)
 /var/log/wtmp.*		--	gen_context(system_u:object_r:wtmp_t,s0)
 
-/run/console(/.*)?	 	gen_context(system_u:object_r:pam_var_console_t,s0)
-/run/faillock(/.*)?		gen_context(system_u:object_r:faillog_t,s0)
-/run/pam_mount(/.*)?	gen_context(system_u:object_r:pam_var_run_t,s0)
-/run/pam_ssh(/.*)?		gen_context(system_u:object_r:var_auth_t,s0)
-/run/sepermit(/.*)? 	gen_context(system_u:object_r:pam_var_run_t,s0)
-/run/sudo(/.*)?		gen_context(system_u:object_r:pam_var_run_t,s0)
 /var/(db|adm)/sudo(/.*)?	gen_context(system_u:object_r:pam_var_run_t,s0)
-/var/lib/sudo(/.*)?	gen_context(system_u:object_r:pam_var_run_t,s0)
+/var/lib/sudo(/.*)?		gen_context(system_u:object_r:pam_var_run_t,s0)

--- a/policy/modules/system/authlogin.if
+++ b/policy/modules/system/authlogin.if
@@ -1826,6 +1826,119 @@ interface(`auth_use_nsswitch',`
 
 ########################################
 ## <summary>
+##	Read utmp file.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auth_read_utmp',`
+	gen_require(`
+		type utmp_t;
+	')
+
+	files_search_pids($1)
+	allow $1 utmp_t:file read_file_perms;
+')
+
+########################################
+## <summary>
+##	Write and read utmp file.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auth_rw_utmp',`
+	gen_require(`
+		type utmp_t;
+	')
+
+	files_search_pids($1)
+	allow $1 utmp_t:file rw_file_perms;
+')
+
+########################################
+## <summary>
+##	Ignore write access on utmp file.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`auth_dontaudit_write_utmp',`
+	gen_require(`
+		type utmp_t;
+	')
+
+	dontaudit $1 utmp_t:file write;
+')
+
+########################################
+## <summary>
+##	Ignore read and write access on utmp file.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`auth_dontaudit_rw_utmp',`
+	gen_require(`
+		type utmp_t;
+	')
+
+	dontaudit $1 utmp_t:file rw_file_perms;
+')
+
+########################################
+## <summary>
+##	Ignore lock access on utmp file.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`auth_dontaudit_lock_utmp',`
+	gen_require(`
+		type utmp_t;
+	')
+
+	dontaudit $1 utmp_t:file lock;
+')
+
+########################################
+## <summary>
+##	Create files in /run with the
+##	utmp file type.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`auth_filetrans_utmp',`
+	gen_require(`
+		type utmp_t;
+	')
+
+	refpolicywarn(`$0($*) has been deprecated.')
+
+	files_pid_filetrans($1, utmp_t, file, "utmp")
+')
+
+########################################
+## <summary>
 ##	Unconfined access to the authlogin module.
 ## </summary>
 ## <desc>

--- a/policy/modules/system/authlogin.te
+++ b/policy/modules/system/authlogin.te
@@ -76,6 +76,12 @@ type utempter_exec_t;
 application_domain(utempter_t, utempter_exec_t)
 
 #
+# utmp_t is the type for /run/utmp_t
+#
+type utmp_t;
+files_pid_file(utmp_t)
+
+#
 # var_auth_t is the type of /var/lib/auth, usually
 # used for auth data in pam_able
 #

--- a/policy/modules/system/getty.te
+++ b/policy/modules/system/getty.te
@@ -85,6 +85,7 @@ term_setattr_unallocated_ttys(getty_t)
 term_setattr_console(getty_t)
 
 auth_rw_login_records(getty_t)
+auth_rw_utmp(getty_t)
 
 init_rw_utmp(getty_t)
 init_use_script_ptys(getty_t)

--- a/policy/modules/system/init.fc
+++ b/policy/modules/system/init.fc
@@ -63,8 +63,7 @@ ifdef(`distro_gentoo', `
 #
 /var/lib/systemd(/.*)?		gen_context(system_u:object_r:init_var_lib_t,s0)
 
-/run/initctl	-p	gen_context(system_u:object_r:initctl_t,s0)
-/run/utmp		--	gen_context(system_u:object_r:initrc_var_run_t,s0)
+/run/initctl		-p	gen_context(system_u:object_r:initctl_t,s0)
 /run/runlevel\.dir		gen_context(system_u:object_r:initrc_var_run_t,s0)
 /run/random-seed	--	gen_context(system_u:object_r:initrc_var_run_t,s0)
 /run/setmixer_flag	--	gen_context(system_u:object_r:initrc_var_run_t,s0)

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -2135,7 +2135,7 @@ interface(`init_script_tmp_filetrans',`
 ##	</summary>
 ## </param>
 #
-interface(`init_getattr_utmp',`
+interface(`init_getattr_initrc',`
 	gen_require(`
 		type initrc_var_run_t;
 	')
@@ -2145,7 +2145,7 @@ interface(`init_getattr_utmp',`
 
 ########################################
 ## <summary>
-##	Read utmp.
+##	Get the attributes of init script process id files. (Deprecated)
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -2153,7 +2153,23 @@ interface(`init_getattr_utmp',`
 ##	</summary>
 ## </param>
 #
-interface(`init_read_utmp',`
+interface(`init_getattr_utmp',`
+	refpolicywarn(`$0($*) has been deprecated.')
+	init_getattr_initrc($*)
+	auth_read_utmp($*)
+')
+
+########################################
+## <summary>
+##	Read init script process id files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_read_initrc',`
 	gen_require(`
 		type initrc_var_run_t;
 	')
@@ -2164,7 +2180,23 @@ interface(`init_read_utmp',`
 
 ########################################
 ## <summary>
-##	Do not audit attempts to write utmp.
+##	Read utmp. (Deprecated)
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_read_utmp',`
+	refpolicywarn(`$0($*) has been deprecated.')
+	init_read_initrc($*)
+	auth_read_utmp($*)
+')
+
+########################################
+## <summary>
+##	Do not audit attempts to write init script process id files.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -2172,7 +2204,7 @@ interface(`init_read_utmp',`
 ##	</summary>
 ## </param>
 #
-interface(`init_dontaudit_write_utmp',`
+interface(`init_dontaudit_write_initrc',`
 	gen_require(`
 		type initrc_var_run_t;
 	')
@@ -2182,7 +2214,42 @@ interface(`init_dontaudit_write_utmp',`
 
 ########################################
 ## <summary>
-##	Write to utmp.
+##	Do not audit attempts to write utmp. (Deprecated)
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`init_dontaudit_write_utmp',`
+	refpolicywarn(`$0($*) has been deprecated.')
+	init_dontaudit_write_initrc($*)
+	auth_dontaudit_write_utmp($*)
+')
+
+########################################
+## <summary>
+##	Write to init script process id files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_write_initrc',`
+	gen_require(`
+		type initrc_var_run_t;
+	')
+
+	files_list_pids($1)
+	allow $1 initrc_var_run_t:file { getattr open write };
+')
+
+########################################
+## <summary>
+##	Write to utmp. (Deprecated)
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -2191,12 +2258,9 @@ interface(`init_dontaudit_write_utmp',`
 ## </param>
 #
 interface(`init_write_utmp',`
-	gen_require(`
-		type initrc_var_run_t;
-	')
-
-	files_list_pids($1)
-	allow $1 initrc_var_run_t:file { getattr open write };
+	refpolicywarn(`$0($*) has been deprecated.')
+	init_write_initrc($*)
+	auth_rw_utmp($*)
 ')
 
 ########################################
@@ -2210,7 +2274,7 @@ interface(`init_write_utmp',`
 ##	</summary>
 ## </param>
 #
-interface(`init_dontaudit_lock_utmp',`
+interface(`init_dontaudit_lock_initrc',`
 	gen_require(`
 		type initrc_var_run_t;
 	')
@@ -2220,7 +2284,24 @@ interface(`init_dontaudit_lock_utmp',`
 
 ########################################
 ## <summary>
-##	Read and write utmp.
+##	Do not audit attempts to lock
+##	init script pid files. (Deprecated)
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`init_dontaudit_lock_utmp',`
+	refpolicywarn(`$0($*) has been deprecated.')
+	init_dontaudit_lock_initrc($*)
+	auth_dontaudit_lock_utmp($*)
+')
+
+########################################
+## <summary>
+##	Read and write init script pid files.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -2228,7 +2309,7 @@ interface(`init_dontaudit_lock_utmp',`
 ##	</summary>
 ## </param>
 #
-interface(`init_rw_utmp',`
+interface(`init_rw_initrc',`
 	gen_require(`
 		type initrc_var_run_t;
 	')
@@ -2239,7 +2320,24 @@ interface(`init_rw_utmp',`
 
 ########################################
 ## <summary>
-##	Do not audit attempts to read and write utmp.
+##	Read and write utmp. (Deprecated)
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_rw_utmp',`
+	refpolicywarn(`$0($*) has been deprecated.')
+	init_rw_initrc($*)
+	auth_rw_utmp($*)
+')
+
+########################################
+## <summary>
+##	Do not audit attempts to read and
+##	write init script pid files.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -2247,7 +2345,7 @@ interface(`init_rw_utmp',`
 ##	</summary>
 ## </param>
 #
-interface(`init_dontaudit_rw_utmp',`
+interface(`init_dontaudit_rw_initrc',`
 	gen_require(`
 		type initrc_var_run_t;
 	')
@@ -2257,7 +2355,23 @@ interface(`init_dontaudit_rw_utmp',`
 
 ########################################
 ## <summary>
-##	Create, read, write, and delete utmp.
+##	Do not audit attempts to read and write utmp. (Deprecated)
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`init_dontaudit_rw_utmp',`
+	refpolicywarn(`$0($*) has been deprecated.')
+	init_dontaudit_rw_initrc($*)
+	auth_dontaudit_rw_utmp($*)
+')
+
+########################################
+## <summary>
+##	Create, read, write, and delete init script pid files.
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -2265,7 +2379,7 @@ interface(`init_dontaudit_rw_utmp',`
 ##	</summary>
 ## </param>
 #
-interface(`init_manage_utmp',`
+interface(`init_manage_initrc',`
 	gen_require(`
 		type initrc_var_run_t;
 	')
@@ -2276,8 +2390,24 @@ interface(`init_manage_utmp',`
 
 ########################################
 ## <summary>
+##	Create, read, write, and delete utmp. (Deprecated)
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`init_manage_utmp',`
+	refpolicywarn(`$0($*) has been deprecated.')
+	init_manage_initrc($*)
+	auth_rw_utmp($*)
+')
+
+########################################
+## <summary>
 ##	Create files in /var/run with the
-##	utmp file type.
+##	utmp file type. (Deprecated)
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -2286,11 +2416,8 @@ interface(`init_manage_utmp',`
 ## </param>
 #
 interface(`init_pid_filetrans_utmp',`
-	gen_require(`
-		type initrc_var_run_t;
-	')
-
-	files_pid_filetrans($1, initrc_var_run_t, file, "utmp")
+	refpolicywarn(`$0($*) has been deprecated.')
+	auth_filetrans_utmp($1)
 ')
 
 ########################################

--- a/policy/modules/system/init.te
+++ b/policy/modules/system/init.te
@@ -332,6 +332,7 @@ ifdef(`distro_redhat',`
 
 optional_policy(`
 	auth_rw_login_records(init_t)
+	auth_rw_utmp(init_t)
 ')
 
 optional_policy(`
@@ -545,6 +546,7 @@ auth_read_pam_pid(initrc_t)
 auth_delete_pam_pid(initrc_t)
 auth_delete_pam_console_data(initrc_t)
 auth_use_nsswitch(initrc_t)
+auth_rw_utmp(initrc_t)
 
 libs_rw_ld_so_cache(initrc_t)
 libs_exec_lib_files(initrc_t)

--- a/policy/modules/system/locallogin.te
+++ b/policy/modules/system/locallogin.te
@@ -123,6 +123,7 @@ auth_rw_faillog(local_login_t)
 auth_manage_pam_pid(local_login_t)
 auth_manage_pam_console_data(local_login_t)
 auth_domtrans_pam_console(local_login_t)
+auth_rw_utmp(local_login_t)
 
 init_dontaudit_use_fds(local_login_t)
 

--- a/policy/modules/system/selinuxutil.te
+++ b/policy/modules/system/selinuxutil.te
@@ -280,6 +280,7 @@ auth_use_nsswitch(newrole_t)
 auth_run_chk_passwd(newrole_t, newrole_roles)
 auth_run_upd_passwd(newrole_t, newrole_roles)
 auth_rw_faillog(newrole_t)
+auth_read_utmp(newrole_t)
 
 # Write to utmp.
 init_rw_utmp(newrole_t)


### PR DESCRIPTION
add a new label for /run/utmp: utmp_t

WARNING: This might break login domains, only tested with console login and ssh on debian sid with systemd

Notice: The old init_*_utmp() interfaces are still in place and have to be reviewed later