### PR TITLE
changes to /run, /run/user and /var/lock

### DIFF
--- a/policy/modules/kernel/files.fc
+++ b/policy/modules/kernel/files.fc
@@ -155,11 +155,7 @@ HOME_ROOT/lost\+found/.*	<<none>>
 #
 /run			-d	gen_context(system_u:object_r:var_run_t,s0-mls_systemhigh)
 /run			-l	gen_context(system_u:object_r:var_run_t,s0)
-/run/.*				gen_context(system_u:object_r:var_run_t,s0)
-/run/.*\.*pid			<<none>>
-
-/run/lock		-d	gen_context(system_u:object_r:var_lock_t,s0)
-/run/lock		-l	gen_context(system_u:object_r:var_lock_t,s0)
+/run/.*				<<none>>
 
 #
 # /selinux
@@ -243,7 +239,10 @@ ifndef(`distro_redhat',`
 
 /var/lib/nfs/rpc_pipefs(/.*)?	<<none>>
 
-/var/lock(/.*)?			gen_context(system_u:object_r:var_lock_t,s0)
+/var/lock		-d	gen_context(system_u:object_r:var_lock_t,s0-mls_systemhigh)
+/var/lock		-l	gen_context(system_u:object_r:var_lock_t,s0)
+/var/lock/subsys	-d	gen_context(system_u:object_r:var_lock_t,s0-mls_systemhigh)
+/var/lock/.*			<<none>>
 
 /var/log/lost\+found	-d	gen_context(system_u:object_r:lost_found_t,mls_systemhigh)
 /var/log/lost\+found/.*		<<none>>


### PR DESCRIPTION
encourage private types for /run and /var/lock by not providing default contexts anymore