### PR TITLE
overlook ssh module

### DIFF
--- a/policy/modules/services/ssh.fc
+++ b/policy/modules/services/ssh.fc
@@ -1,23 +1,24 @@
-HOME_DIR/\.ssh(/.*)?			gen_context(system_u:object_r:ssh_home_t,s0)
+HOME_DIR/\.ssh(/.*)?				gen_context(system_u:object_r:ssh_home_t,s0)
 
-/etc/ssh/primes			--	gen_context(system_u:object_r:sshd_key_t,s0)
-/etc/ssh/ssh_host.*_key		--	gen_context(system_u:object_r:sshd_key_t,s0)
+/etc/ssh(/.*)?					gen_context(system_u:object_r:ssh_conf_t,s0)
+/etc/ssh/primes				--	gen_context(system_u:object_r:sshd_key_t,s0)
+/etc/ssh/ssh_host.*_key			--	gen_context(system_u:object_r:sshd_key_t,s0)
 
-/usr/bin/ssh			--	gen_context(system_u:object_r:ssh_exec_t,s0)
-/usr/bin/ssh-agent		--	gen_context(system_u:object_r:ssh_agent_exec_t,s0)
-/usr/bin/ssh-keygen		--	gen_context(system_u:object_r:ssh_keygen_exec_t,s0)
+/run/sshd(/.*)?					gen_context(system_u:object_r:sshd_pid_t,s0)
+/run/sshd\.init\.pid			--	gen_context(system_u:object_r:sshd_pid_t,s0)
+/run/sshd\.pid				--	gen_context(system_u:object_r:sshd_pid_t,s0)
 
-/usr/lib/openssh/ssh-keysign	--	gen_context(system_u:object_r:ssh_keysign_exec_t,s0)
-/usr/lib/ssh/ssh-keysign	--	gen_context(system_u:object_r:ssh_keysign_exec_t,s0)
+/usr/bin/ssh				--	gen_context(system_u:object_r:ssh_exec_t,s0)
+/usr/bin/ssh-agent			--	gen_context(system_u:object_r:ssh_agent_exec_t,s0)
+/usr/bin/ssh-keygen			--	gen_context(system_u:object_r:ssh_keygen_exec_t,s0)
+
+/usr/lib/openssh/ssh-keysign		--	gen_context(system_u:object_r:ssh_keysign_exec_t,s0)
+/usr/lib/ssh/ssh-keysign		--	gen_context(system_u:object_r:ssh_keysign_exec_t,s0)
 
 /usr/lib/systemd/system/ssh.*		--	gen_context(system_u:object_r:sshd_unit_t,s0)
 /usr/lib/systemd/system/sshdgenkeys.*	--	gen_context(system_u:object_r:sshd_keygen_unit_t,s0)
 /usr/lib/systemd/system/sshd-keygen.*	--	gen_context(system_u:object_r:sshd_keygen_unit_t,s0)
 
-/usr/libexec/openssh/ssh-keysign --	gen_context(system_u:object_r:ssh_keysign_exec_t,s0)
+/usr/libexec/openssh/ssh-keysign	--	gen_context(system_u:object_r:ssh_keysign_exec_t,s0)
 
-/usr/sbin/sshd			--	gen_context(system_u:object_r:sshd_exec_t,s0)
-
-/run/sshd(/.*)?			gen_context(system_u:object_r:sshd_var_run_t,s0)
-/run/sshd\.init\.pid	--	gen_context(system_u:object_r:sshd_var_run_t,s0)
-/run/sshd\.pid		--	gen_context(system_u:object_r:sshd_var_run_t,s0)
+/usr/sbin/sshd				--	gen_context(system_u:object_r:sshd_exec_t,s0)

--- a/policy/modules/services/ssh.if
+++ b/policy/modules/services/ssh.if
@@ -57,7 +57,6 @@ template(`ssh_basic_client_template',`
 	#
 
 	allow $1_ssh_t self:capability { setuid setgid dac_override dac_read_search };
-	allow $1_ssh_t self:process ~{ ptrace setcurrent setexec setfscreate setrlimit execmem execstack execheap };
 	allow $1_ssh_t self:fd use;
 	allow $1_ssh_t self:fifo_file rw_fifo_file_perms;
 	allow $1_ssh_t self:unix_dgram_socket { create_socket_perms sendto };
@@ -143,6 +142,8 @@ template(`ssh_basic_client_template',`
 
 	seutil_read_config($1_ssh_t)
 
+	ssh_read_conf($1_ssh_t)
+
 	optional_policy(`
 		kerberos_use($1_ssh_t)
 	')
@@ -178,10 +179,12 @@ template(`ssh_server_template', `
 	type $1_tmpfs_t;
 	files_tmpfs_file($1_tmpfs_t)
 
-	type $1_var_run_t;
-	files_pid_file($1_var_run_t)
+	type $1_pid_t;
+	typealias $1_pid_t alias $1_var_run_t;
+	files_pid_file($1_pid_t)
 
 	allow $1_t self:capability { kill sys_chroot sys_nice sys_resource chown dac_override fowner fsetid setgid setuid sys_tty_config };
+	dontaudit $1_t self:capability net_admin;
 	allow $1_t self:fifo_file rw_fifo_file_perms;
 	allow $1_t self:process { signal getsched setsched setrlimit setexec setkeycreate };
 	allow $1_t self:tcp_socket create_stream_socket_perms;
@@ -196,9 +199,9 @@ template(`ssh_server_template', `
 	manage_files_pattern($1_t, $1_tmpfs_t, $1_tmpfs_t)
 	fs_tmpfs_filetrans($1_t, $1_tmpfs_t, file)
 
-	allow $1_t $1_var_run_t:dir search_dir_perms;
-	allow $1_t $1_var_run_t:file manage_file_perms;
-	files_pid_filetrans($1_t, $1_var_run_t, file)
+	allow $1_t $1_pid_t:dir search_dir_perms;
+	allow $1_t $1_pid_t:file manage_file_perms;
+	files_pid_filetrans($1_t, $1_pid_t, file)
 
 	can_exec($1_t, sshd_exec_t)
 
@@ -247,6 +250,8 @@ template(`ssh_server_template', `
 	userdom_create_all_users_keys($1_t)
 	userdom_dontaudit_relabelfrom_user_ptys($1_t)
 	userdom_search_user_home_dirs($1_t)
+
+	ssh_read_conf($1_t)
 
 	# Allow checking users mail at login
 	optional_policy(`
@@ -581,20 +586,6 @@ interface(`ssh_dontaudit_rw_tcp_sockets',`
 
 ########################################
 ## <summary>
-##	Connect to SSH daemons over TCP sockets.  (Deprecated)
-## </summary>
-## <param name="domain">
-##	<summary>
-##	Domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`ssh_tcp_connect',`
-	refpolicywarn(`$0($*) has been deprecated.')
-')
-
-########################################
-## <summary>
 ##	Execute the ssh daemon sshd domain.
 ## </summary>
 ## <param name="domain">
@@ -761,4 +752,23 @@ interface(`ssh_delete_tmp',`
 
 	files_search_tmp($1)
 	delete_files_pattern($1, sshd_tmp_t, sshd_tmp_t)
+')
+
+#######################################
+## <summary>
+##	Read the ssh conf files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`ssh_read_conf',`
+	gen_require(`
+		type ssh_conf_t;
+	')
+
+	files_search_etc($1)
+	read_files_pattern($1, ssh_conf_t, ssh_conf_t)
 ')

--- a/policy/modules/services/ssh.te
+++ b/policy/modules/services/ssh.te
@@ -7,10 +7,10 @@ policy_module(ssh, 2.8.1)
 
 ## <desc>
 ## <p>
-## allow host key based authentication
+## Allow host key based authentication
 ## </p>
 ## </desc>
-gen_tunable(allow_ssh_keysign, false)
+gen_tunable(ssh_keysign, false)
 
 ## <desc>
 ## <p>
@@ -29,33 +29,30 @@ gen_tunable(ssh_use_gpg_agent, false)
 attribute ssh_server;
 attribute ssh_agent_type;
 
-type ssh_keygen_t;
-type ssh_keygen_exec_t;
-init_system_domain(ssh_keygen_t, ssh_keygen_exec_t)
-role system_r types ssh_keygen_t;
-
 type sshd_exec_t;
 corecmd_executable_file(sshd_exec_t)
 
 ssh_server_template(sshd)
 init_daemon_domain(sshd_t, sshd_exec_t)
+ifdef(`enable_mcs',`
+	init_ranged_daemon_domain(sshd_t, sshd_exec_t, s0 - mcs_systemhigh)
+')
 
 type sshd_key_t;
 files_type(sshd_key_t)
+
+type sshd_keygen_unit_t;
+init_unit_file(sshd_keygen_unit_t)
+
+type sshd_keytab_t;
+files_type(sshd_keytab_t)
 
 type sshd_tmp_t;
 files_tmp_file(sshd_tmp_t)
 files_poly_parent(sshd_tmp_t)
 
-type sshd_keygen_unit_t;
-init_unit_file(sshd_keygen_unit_t)
-
 type sshd_unit_t;
 init_unit_file(sshd_unit_t)
-
-ifdef(`enable_mcs',`
-	init_ranged_daemon_domain(sshd_t, sshd_exec_t, s0 - mcs_systemhigh)
-')
 
 type ssh_t;
 type ssh_exec_t;
@@ -67,32 +64,25 @@ type ssh_agent_exec_t;
 corecmd_executable_file(ssh_agent_exec_t)
 
 type ssh_agent_tmp_t;
-typealias ssh_agent_tmp_t alias { user_ssh_agent_tmp_t staff_ssh_agent_tmp_t sysadm_ssh_agent_tmp_t };
-typealias ssh_agent_tmp_t alias { auditadm_ssh_agent_tmp_t secadm_ssh_agent_tmp_t };
 userdom_user_tmp_file(ssh_agent_tmp_t)
+
+type ssh_conf_t;
+files_config_file(ssh_conf_t)
+
+type ssh_keygen_t;
+type ssh_keygen_exec_t;
+init_system_domain(ssh_keygen_t, ssh_keygen_exec_t)
+role system_r types ssh_keygen_t;
 
 type ssh_keysign_t;
 type ssh_keysign_exec_t;
-typealias ssh_keysign_t alias { user_ssh_keysign_t staff_ssh_keysign_t sysadm_ssh_keysign_t };
-typealias ssh_keysign_t alias { auditadm_ssh_keysign_t secadm_ssh_keysign_t };
 userdom_user_application_domain(ssh_keysign_t, ssh_keysign_exec_t)
 
 type ssh_tmpfs_t;
-typealias ssh_tmpfs_t alias { user_ssh_tmpfs_t staff_ssh_tmpfs_t sysadm_ssh_tmpfs_t };
-typealias ssh_tmpfs_t alias { auditadm_ssh_tmpfs_t secadm_ssh_tmpfs_t };
 userdom_user_tmpfs_file(ssh_tmpfs_t)
 
 type ssh_home_t;
-typealias ssh_home_t alias { home_ssh_t user_ssh_home_t user_home_ssh_t staff_home_ssh_t sysadm_home_ssh_t };
-typealias ssh_home_t alias { auditadm_home_ssh_t secadm_home_ssh_t };
 userdom_user_home_content(ssh_home_t)
-
-type sshd_keytab_t;
-files_type(sshd_keytab_t)
-
-ifdef(`distro_debian',`
-	init_daemon_pid_file(sshd_var_run_t, dir, "sshd")
-')
 
 ##############################
 #
@@ -100,7 +90,6 @@ ifdef(`distro_debian',`
 #
 
 allow ssh_t self:capability { setuid setgid dac_override dac_read_search };
-allow ssh_t self:process ~{ ptrace setcurrent setexec setfscreate setrlimit execmem execstack execheap };
 allow ssh_t self:fd use;
 allow ssh_t self:fifo_file rw_fifo_file_perms;
 allow ssh_t self:unix_dgram_socket { create_socket_perms sendto };
@@ -187,7 +176,7 @@ userdom_use_user_terminals(ssh_t)
 # needs to read krb tgt
 userdom_read_user_tmp_files(ssh_t)
 
-tunable_policy(`allow_ssh_keysign',`
+tunable_policy(`ssh_keysign',`
 	domain_auto_transition_pattern(ssh_t, ssh_keysign_exec_t, ssh_keysign_t)
 	allow ssh_keysign_t ssh_t:fd use;
 	allow ssh_keysign_t ssh_t:process sigchld;
@@ -268,13 +257,10 @@ term_relabelto_all_ptys(sshd_t)
 corenet_tcp_bind_xserver_port(sshd_t)
 corenet_sendrecv_xserver_server_packets(sshd_t)
 
-ifdef(`distro_debian',`
-	allow sshd_t self:process { getcap setcap };
-')
-
 ifdef(`init_systemd',`
 	systemd_dbus_chat_logind(sshd_t)
 	init_rw_stream_sockets(sshd_t)
+	userdom_search_user_runtime(sshd_t)
 ')
 
 tunable_policy(`ssh_sysadm_login',`
@@ -361,10 +347,6 @@ auth_use_nsswitch(ssh_keygen_t)
 logging_send_syslog_msg(ssh_keygen_t)
 
 userdom_dontaudit_use_unpriv_user_fds(ssh_keygen_t)
-
-optional_policy(`
-	seutil_sigchld_newrole(ssh_keygen_t)
-')
 
 optional_policy(`
 	udev_read_db(ssh_keygen_t)


### PR DESCRIPTION
* rename sshd_var_run_t to sshd_run_t
* rename allow_ssh_keysign to ssh_keysign to prefix-match module
* do not use negativ permissions granting allow * *:* ~{ xy};
* create new label ssh_conf_t for /etc/ssh