### PR TITLE
terminal: label content of /dev/pts/ correctly

### DIFF
--- a/policy/modules/kernel/terminal.fc
+++ b/policy/modules/kernel/terminal.fc
@@ -14,7 +14,6 @@
 /dev/ip2[^/]*		-c	gen_context(system_u:object_r:tty_device_t,s0)
 /dev/isdn.*		-c	gen_context(system_u:object_r:tty_device_t,s0)
 /dev/ptmx		-c	gen_context(system_u:object_r:ptmx_t,s0)
-/dev/pts/ptmx		-c	gen_context(system_u:object_r:ptmx_t,s0)
 /dev/rfcomm[0-9]+	-c	gen_context(system_u:object_r:tty_device_t,s0)
 /dev/slamr[0-9]+	-c	gen_context(system_u:object_r:tty_device_t,s0)
 /dev/tty		-c	gen_context(system_u:object_r:devtty_t,s0)
@@ -25,6 +24,8 @@
 /dev/pty/.*		-c	gen_context(system_u:object_r:bsdpty_device_t,s0)
 
 /dev/pts		-d	gen_context(system_u:object_r:devpts_t,s0-mls_systemhigh)
+/dev/pts/ptmx		-c	gen_context(system_u:object_r:devpts_t,s0)
+/dev/pts/[0-9]+		-c	gen_context(system_u:object_r:user_devpts_t,s0)
 
 /dev/tts/[^/]*		-c	gen_context(system_u:object_r:tty_device_t,s0)
 
@@ -37,7 +38,7 @@
 /dev/xvc[0-9]*		-c	gen_context(system_u:object_r:tty_device_t,s0)
 
 ifdef(`distro_gentoo',`
-/dev/tts/[0-9]*		-c	gen_context(system_u:object_r:tty_device_t,s0)
+/dev/tts/[0-9]+		-c	gen_context(system_u:object_r:tty_device_t,s0)
 
 # used by init scripts to initally populate udev /dev
 /lib/udev/devices/console -c	gen_context(system_u:object_r:console_device_t,s0)


### PR DESCRIPTION
* label content of /dev/pts/ correctly
