### PR TITLE
filesystem: label tracefs correct when not yet mounted

### DIFF
--- a/policy/modules/kernel/filesystem.te
+++ b/policy/modules/kernel/filesystem.te
@@ -174,6 +174,7 @@ genfscon v7 / gen_context(system_u:object_r:sysv_t,s0)
 type tracefs_t;
 fs_type(tracefs_t)
 genfscon tracefs / gen_context(system_u:object_r:tracefs_t,s0)
+genfscon debugfs /tracing gen_context(system_u:object_r:tracefs_t,s0)
 
 type vmblock_t;
 fs_noxattr_type(vmblock_t)


### PR DESCRIPTION
* label tracefs correct when not yet mounted