### PR TITLE
Make "validate" target verify file contexts

### DIFF
--- a/Rules.modular
+++ b/Rules.modular
@@ -5,6 +5,7 @@
 
 all_modules := $(base_mods) $(mod_mods) $(off_mods)
 all_interfaces := $(all_modules:.te=.if)
+all_mod_fc := $(addprefix $(tmpdir)/,$(notdir $(all_modules:.te=.mod.fc)))
 
 base_pkg := $(builddir)base.pp
 base_fc := $(builddir)base.fc
@@ -30,7 +31,7 @@ vpath %.te $(all_layers)
 vpath %.if $(all_layers)
 vpath %.fc $(all_layers)
 
-.SECONDARY: $(addprefix $(tmpdir)/,$(mod_pkgs:.pp=.mod)) $(addprefix $(tmpdir)/,$(mod_pkgs:.pp=.mod.fc))
+.SECONDARY: $(all_mod_fc:.mod.fc=.mod) $(all_mod_fc)
 
 ########################################
 #
@@ -84,6 +85,9 @@ $(builddir)%.pp: $(tmpdir)/%.mod $(tmpdir)/%.mod.fc
 	@echo "Creating $(NAME) $(@F) policy package"
 	@test -d $(builddir) || mkdir -p $(builddir)
 	$(verbose) $(SEMOD_PKG) -o $@ -m $< -f $<.fc
+
+$(tmpdir)/all_mods.fc: $(all_mod_fc)
+	$(verbose) cat $^ > $@
 
 ########################################
 #
@@ -198,10 +202,12 @@ $(appdir)/customizable_types: $(base_conf)
 #
 # Validate linking and expanding of modules
 #
-validate: $(base_pkg) $(mod_pkgs)
+validate: $(base_pkg) $(mod_pkgs) $(tmpdir)/all_mods.fc
 	@echo "Validating policy linking."
-	$(verbose) $(SEMOD_LNK) -o $(tmpdir)/test.lnk $^
+	$(verbose) $(SEMOD_LNK) -o $(tmpdir)/test.lnk $(base_pkg) $(mod_pkgs)
 	$(verbose) $(SEMOD_EXP) $(tmpdir)/test.lnk $(tmpdir)/policy.bin
+	@echo "Validating policy file contexts."
+	$(verbose) $(SETFILES) -q -c $(tmpdir)/policy.bin $(tmpdir)/all_mods.fc
 	@echo "Success."
 
 ########################################

--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -185,7 +185,7 @@ ifdef(`distro_suse', `
 
 ifdef(`distro_debian',`
 # this is a static /dev dir "backup mount"
-# if you want to disable udev, you'll have to boot permissive and relabel!
+# if you want to disable udev, you will have to boot permissive and relabel!
 /dev/\.static		-d	gen_context(system_u:object_r:device_t,s0)
 /dev/\.static/dev	-d	gen_context(system_u:object_r:device_t,s0)
 /dev/\.static/dev/(.*)?		<<none>>


### PR DESCRIPTION
Hello,
This Pull Request makes ``make validate`` able to detect some errors related to file contexts, using ``setfiles``. I  have written it after I stumbled on git mismerges in ``systemd.fc`` which were not reported by ``make validate`` but made loading the policy fail.
When I tested this change on Travis-CI, the builds with ``DISTRO=debian MONOLITHIC=n`` failed because of a syntax issue cause by a single quote in a comment. Even though I find it weird that m4 keeps the comments (contrary to the C preprocessor for example), I fixed this failure by removing the buggy quote.