### PR TITLE
Use raw strings in regular expressions

### DIFF
--- a/support/pyplate.py
+++ b/support/pyplate.py
@@ -54,14 +54,14 @@ PyPlate defines the following directives:
 
 import sys, re, io
 
-re_directive = re.compile("\[\[(.*)\]\]")
-re_for_loop = re.compile("for (.*) in (.*)")
-re_if = re.compile("if (.*)")
-re_elif = re.compile("elif (.*)")
-re_def = re.compile("def (.*?)\((.*)\)")
-re_call = re.compile("call (.*?)\((.*)\)")
-re_exec = re.compile("exec (.*)")
-re_comment = re.compile("#(.*)#")
+re_directive = re.compile(r"\[\[(.*)\]\]")
+re_for_loop = re.compile(r"for (.*) in (.*)")
+re_if = re.compile(r"if (.*)")
+re_elif = re.compile(r"elif (.*)")
+re_def = re.compile(r"def (.*?)\((.*)\)")
+re_call = re.compile(r"call (.*?)\((.*)\)")
+re_exec = re.compile(r"exec (.*)")
+re_comment = re.compile(r"#(.*)#")
 
 ############################################################
 # Template parser

--- a/support/segenxml.py
+++ b/support/segenxml.py
@@ -34,7 +34,7 @@ output_dir = ""
 #	 -> ("interface", "kernel_read_system_state")
 #	"template(`base_user_template',`"
 #	 -> ("template", "base_user_template")
-INTERFACE = re.compile("^\s*(interface|template)\(`(\w*)'")
+INTERFACE = re.compile(r"^\s*(interface|template)\(`(\w*)'")
 
 # Matches either a gen_bool or a gen_tunable statement. Will give the tuple:
 #	("tunable" or "bool", name, "true" or "false")
@@ -43,7 +43,7 @@ INTERFACE = re.compile("^\s*(interface|template)\(`(\w*)'")
 #	 -> ("bool", "secure_mode", "false")
 #	"gen_tunable(allow_kerberos, false)"
 #	 -> ("tunable", "allow_kerberos", "false")
-BOOLEAN = re.compile("^\s*gen_(tunable|bool)\(\s*(\w*)\s*,\s*(true|false)\s*\)")
+BOOLEAN = re.compile(r"^\s*gen_(tunable|bool)\(\s*(\w*)\s*,\s*(true|false)\s*\)")
 
 # Matches a XML comment in the policy, which is defined as any line starting
 #  with two # and at least one character of white space. Will give the single
@@ -54,7 +54,7 @@ BOOLEAN = re.compile("^\s*gen_(tunable|bool)\(\s*(\w*)\s*,\s*(true|false)\s*\)")
 #	 -> ("<summary>")
 #	"##		The domain allowed access.	"
 #	 -> ("The domain allowed access.")
-XML_COMMENT = re.compile("^##\s+(.*?)\s*$")
+XML_COMMENT = re.compile(r"^##\s+(.*?)\s*$")
 
 
 # FUNCTIONS


### PR DESCRIPTION
Python 3.6 complains about the strings which are used as regular
expression in the support scripts:

    File "support/segenxml.py", line 37
        INTERFACE = re.compile("^\s*(interface|template)\(`(\w*)'")
                              ^
    SyntaxError: invalid escape sequence \s