### PR TITLE
bootloader: update

### DIFF
--- a/policy/modules/admin/bootloader.fc
+++ b/policy/modules/admin/bootloader.fc
@@ -1,6 +1,6 @@
 
-/etc/lilo\.conf.*	--	gen_context(system_u:object_r:bootloader_etc_t,s0)
-/etc/yaboot\.conf.*	--	gen_context(system_u:object_r:bootloader_etc_t,s0)
+/etc/lilo\.conf.*		--	gen_context(system_u:object_r:bootloader_etc_t,s0)
+/etc/yaboot\.conf.*		--	gen_context(system_u:object_r:bootloader_etc_t,s0)
 
 /usr/bin/grub			--	gen_context(system_u:object_r:bootloader_exec_t,s0)
 /usr/bin/grub2?-bios-setup	--	gen_context(system_u:object_r:bootloader_exec_t,s0)
@@ -10,12 +10,12 @@
 /usr/bin/lilo.*			--	gen_context(system_u:object_r:bootloader_exec_t,s0)
 /usr/bin/ybin.*			--	gen_context(system_u:object_r:bootloader_exec_t,s0)
 
-/usr/sbin/grub		--	gen_context(system_u:object_r:bootloader_exec_t,s0)
+/usr/sbin/grub			--	gen_context(system_u:object_r:bootloader_exec_t,s0)
 /usr/sbin/grub2?-bios-setup	--	gen_context(system_u:object_r:bootloader_exec_t,s0)
 /usr/sbin/grub2?-install	--	gen_context(system_u:object_r:bootloader_exec_t,s0)
 /usr/sbin/grub2?-mkconfig	--	gen_context(system_u:object_r:bootloader_exec_t,s0)
-/usr/sbin/grub2?-probe	--	gen_context(system_u:object_r:bootloader_exec_t,s0)
-/usr/sbin/lilo.*	--	gen_context(system_u:object_r:bootloader_exec_t,s0)
-/usr/sbin/ybin.*	--	gen_context(system_u:object_r:bootloader_exec_t,s0)
+/usr/sbin/grub2?-probe		--	gen_context(system_u:object_r:bootloader_exec_t,s0)
+/usr/sbin/lilo.*		--	gen_context(system_u:object_r:bootloader_exec_t,s0)
+/usr/sbin/ybin.*		--	gen_context(system_u:object_r:bootloader_exec_t,s0)
 
-/var/lib/os-prober(/.*)?	gen_context(system_u:object_r:bootloader_tmp_t,s0)
+/var/lib/os-prober(/.*)?		gen_context(system_u:object_r:bootloader_tmp_t,s0)

--- a/policy/modules/admin/bootloader.fc
+++ b/policy/modules/admin/bootloader.fc
@@ -1,6 +1,6 @@
-
-/etc/lilo\.conf.*		--	gen_context(system_u:object_r:bootloader_etc_t,s0)
-/etc/yaboot\.conf.*		--	gen_context(system_u:object_r:bootloader_etc_t,s0)
+/etc/grub\.d/.+			--	gen_context(system_u:object_r:bootloader_script_exec_t,s0)
+/etc/lilo\.conf.*		--	gen_context(system_u:object_r:bootloader_conf_t,s0)
+/etc/yaboot\.conf.*		--	gen_context(system_u:object_r:bootloader_conf_t,s0)
 
 /usr/bin/grub			--	gen_context(system_u:object_r:bootloader_exec_t,s0)
 /usr/bin/grub2?-bios-setup	--	gen_context(system_u:object_r:bootloader_exec_t,s0)

--- a/policy/modules/admin/bootloader.if
+++ b/policy/modules/admin/bootloader.if
@@ -76,10 +76,10 @@ interface(`bootloader_exec',`
 #
 interface(`bootloader_read_config',`
 	gen_require(`
-		type bootloader_etc_t;
+		type bootloader_conf_t;
 	')
 
-	allow $1 bootloader_etc_t:file read_file_perms;
+	allow $1 bootloader_conf_t:file read_file_perms;
 ')
 
 ########################################
@@ -96,10 +96,10 @@ interface(`bootloader_read_config',`
 #
 interface(`bootloader_rw_config',`
 	gen_require(`
-		type bootloader_etc_t;
+		type bootloader_conf_t;
 	')
 
-	allow $1 bootloader_etc_t:file rw_file_perms;
+	allow $1 bootloader_conf_t:file rw_file_perms;
 ')
 
 ########################################

--- a/policy/modules/admin/bootloader.te
+++ b/policy/modules/admin/bootloader.te
@@ -8,25 +8,24 @@ policy_module(bootloader, 1.17.7)
 attribute_role bootloader_roles;
 roleattribute system_r bootloader_roles;
 
-#
-# boot_runtime_t is the type for /boot/kernel.h,
-# which is automatically generated at boot time.
-# only for Red Hat
-#
-type boot_runtime_t;
-files_type(boot_runtime_t)
-
 type bootloader_t;
 type bootloader_exec_t;
 application_domain(bootloader_t, bootloader_exec_t)
 role bootloader_roles types bootloader_t;
 
 #
-# bootloader_etc_t is the configuration file,
+# bootloader_conf_t is the configuration file,
 # grub.conf, lilo.conf, etc.
 #
-type bootloader_etc_t alias etc_bootloader_t;
-files_type(bootloader_etc_t)
+type bootloader_conf_t alias bootloader_etc_t;
+files_config_file(bootloader_conf_t)
+
+#
+# bootloader_script_exec_t is for executable scipts
+# e.g. under /etc/grub.d/
+#
+type bootloader_script_exec_t;
+files_type(bootloader_script_exec_t)
 
 #
 # The temp file is used for initrd creation;
@@ -45,10 +44,14 @@ allow bootloader_t self:capability { chown dac_override dac_read_search fsetid m
 allow bootloader_t self:process { signal_perms execmem };
 allow bootloader_t self:fifo_file rw_fifo_file_perms;
 
-allow bootloader_t bootloader_etc_t:file read_file_perms;
+allow bootloader_t bootloader_conf_t:file read_file_perms;
 # uncomment the following lines if you use "lilo -p"
-#allow bootloader_t bootloader_etc_t:file manage_file_perms;
-#files_etc_filetrans(bootloader_t,bootloader_etc_t,file)
+#allow bootloader_t bootloader_conf_t:file manage_file_perms;
+#files_etc_filetrans(bootloader_t,bootloader_conf_t,file)
+
+can_exec(bootloader_t, bootloader_exec_t)
+
+can_exec(bootloader_t, bootloader_script_exec_t)
 
 manage_dirs_pattern(bootloader_t, bootloader_tmp_t, bootloader_tmp_t)
 manage_files_pattern(bootloader_t, bootloader_tmp_t, bootloader_tmp_t)
@@ -97,7 +100,8 @@ mls_file_write_all_levels(bootloader_t)
 term_getattr_all_ttys(bootloader_t)
 term_dontaudit_manage_pty_dirs(bootloader_t)
 
-corecmd_exec_all_executables(bootloader_t)
+corecmd_exec_bin(bootloader_t)
+corecmd_exec_shell(bootloader_t)
 
 domain_use_interactive_fds(bootloader_t)
 
@@ -105,7 +109,6 @@ files_create_boot_dirs(bootloader_t)
 files_manage_boot_files(bootloader_t)
 files_manage_boot_symlinks(bootloader_t)
 files_read_etc_files(bootloader_t)
-files_exec_etc_files(bootloader_t)
 files_read_usr_src_files(bootloader_t)
 files_read_usr_files(bootloader_t)
 files_read_var_files(bootloader_t)
@@ -127,8 +130,7 @@ fs_getattr_fusefs(bootloader_t)
 fs_unmount_fusefs(bootloader_t)
 fs_unmount_xattr_fs(bootloader_t)
 
-fstools_manage_runtime_files(bootloader_t)
-
+init_check_exec(bootloader_t)
 init_getattr_initctl(bootloader_t)
 init_use_script_ptys(bootloader_t)
 init_use_script_fds(bootloader_t)
@@ -147,8 +149,6 @@ mount_rw_runtime_files(bootloader_t)
 seutil_read_bin_policy(bootloader_t)
 seutil_read_loadpolicy(bootloader_t)
 seutil_dontaudit_search_config(bootloader_t)
-
-udev_read_pid_files(bootloader_t)
 
 userdom_use_user_terminals(bootloader_t)
 userdom_dontaudit_search_user_home_dirs(bootloader_t)
@@ -174,6 +174,8 @@ ifdef(`distro_debian',`
 	apt_read_db(bootloader_t)
 	apt_read_cache(bootloader_t)
 
+	# dpkg --compare-versions
+	dpkg_exec(bootloader_t)
 	dpkg_read_db(bootloader_t)
 	dpkg_rw_pipes(bootloader_t)
 ')
@@ -181,6 +183,13 @@ ifdef(`distro_debian',`
 ifdef(`distro_redhat',`
 	# for memlock
 	allow bootloader_t self:capability ipc_lock;
+
+	#
+	# boot_runtime_t is the type for /boot/kernel.h,
+	# which is automatically generated at boot time.
+	#
+	type boot_runtime_t;
+	files_type(boot_runtime_t)
 
 	allow bootloader_t boot_runtime_t:file { read_file_perms delete_file_perms };
 
@@ -201,6 +210,8 @@ ifdef(`distro_redhat',`
 
 optional_policy(`
 	fstools_exec(bootloader_t)
+	fstools_manage_runtime_files(bootloader_t)
+	fstools_pid_filetrans(bootloader_t, dir, "blkid")
 ')
 
 optional_policy(`
@@ -231,4 +242,14 @@ optional_policy(`
 
 optional_policy(`
 	rpm_rw_pipes(bootloader_t)
+')
+
+optional_policy(`
+	# udevadm
+	udev_exec(bootloader_t)
+	udev_read_pid_files(bootloader_t)
+
+	seutil_read_config(bootloader_t)
+	seutil_read_file_contexts(bootloader_t)
+	selinux_get_enforce_mode(bootloader_t)
 ')

--- a/policy/modules/system/fstools.if
+++ b/policy/modules/system/fstools.if
@@ -175,6 +175,36 @@ interface(`fstools_write_log',`
 
 ########################################
 ## <summary>
+##	Create runtime files with the fsadm private type.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="object">
+##	<summary>
+##	The object class of the object being created.
+##	</summary>
+## </param>
+## <param name="name" optional="true">
+##	<summary>
+##	The name of the object being created.
+##	</summary>
+## </param>
+#
+interface(`fstools_pid_filetrans',`
+	gen_require(`
+		type fsadm_run_t;
+	')
+
+	files_search_pids($1)
+
+	files_pid_filetrans($1, fsadm_run_t, $2, $3)
+')
+
+########################################
+## <summary>
 ##	Create, read, write, and delete filesystem tools
 ##	runtime files.
 ## </summary>

--- a/policy/modules/system/init.if
+++ b/policy/modules/system/init.if
@@ -611,6 +611,26 @@ interface(`init_domtrans',`
 
 ########################################
 ## <summary>
+##	Check if init is executable. (DAC wise)
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+## <rolecap/>
+#
+interface(`init_check_exec',`
+        gen_require(`
+                type init_exec_t;
+        ')
+
+        corecmd_search_bin($1)
+        allow $1 init_exec_t:file { execute getattr };
+')
+
+########################################
+## <summary>
 ##	Execute the init program in the caller domain.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
* introduce `bootloader_script_exec_t` to avoid `files_exec_etc_files`
* split up `corecmd_exec_all_executables`