### PR TITLE
Update for Xen 4.7

### DIFF
--- a/policy/modules/kernel/devices.fc
+++ b/policy/modules/kernel/devices.fc
@@ -182,6 +182,7 @@ ifdef(`distro_suse', `
 /dev/xen/evtchn		-c	gen_context(system_u:object_r:xen_device_t,s0)
 /dev/xen/gntdev		-c	gen_context(system_u:object_r:xen_device_t,s0)
 /dev/xen/gntalloc	-c	gen_context(system_u:object_r:xen_device_t,s0)
+/dev/xen/privcmd	-c	gen_context(system_u:object_r:xen_device_t,s0)
 
 ifdef(`distro_debian',`
 # this is a static /dev dir "backup mount"


### PR DESCRIPTION
Since Xen 4.7, /dev/xen/privcmd is used instead of /proc/xen/privcmd.
Add the device into the policy so `xenstored` can work.