### PR TITLE
Avoid memory leak warning.

### DIFF
--- a/support/fc_sort.c
+++ b/support/fc_sort.c
@@ -512,7 +512,7 @@ int main(int argc, char *argv[])
 			if (!(bcurrent->next)) {
 				printf
 				    ("Error: failure allocating memory.\n");
-				return -1;
+				exit(-1);
 			}
 
 			/* Make sure the new bucket thinks it's the end of the


### PR DESCRIPTION
Using the LLVM static analyzer, we get a warning about leaked memory
pointed by bcurrent. Since the warning happens within "main", we
don't care about deallocating the memory and just call "exit" which
gets rid of the warning.