### PR TITLE
system/ipsec: Add signull access for strongSwan

### DIFF
--- a/policy/modules/system/ipsec.te
+++ b/policy/modules/system/ipsec.te
@@ -461,7 +461,7 @@ userdom_use_user_terminals(setkey_t)
 #
 
 allow ipsec_supervisor_t self:capability { dac_override dac_read_search kill net_admin };
-allow ipsec_supervisor_t self:process { signal };
+allow ipsec_supervisor_t self:process { signal signull };
 allow ipsec_supervisor_t self:fifo_file rw_fifo_file_perms;
 allow ipsec_supervisor_t self:netlink_route_socket rw_netlink_socket_perms;
 allow ipsec_supervisor_t self:netlink_xfrm_socket create_netlink_socket_perms;
@@ -472,7 +472,7 @@ read_files_pattern(ipsec_supervisor_t, ipsec_conf_file_t, ipsec_conf_file_t);
 manage_files_pattern(ipsec_supervisor_t, ipsec_key_file_t, ipsec_key_file_t)
 
 allow ipsec_supervisor_t ipsec_t:unix_stream_socket { connectto };
-allow ipsec_supervisor_t ipsec_t:process { signal };
+allow ipsec_supervisor_t ipsec_t:process { signal signull };
 
 allow ipsec_supervisor_t ipsec_var_run_t:sock_file { rw_sock_file_perms unlink };
 manage_dirs_pattern(ipsec_supervisor_t, ipsec_var_run_t, ipsec_var_run_t)


### PR DESCRIPTION
The strongSwan starter application, running as ipsec_supervisor_t, uses signull to check for the existence of other ipsec_t and ipsec_supervisor_t running processes. Without the signull permission running 'ipsec start' multiple times will cause multiple instances of the charon daemon to run. 