### PR TITLE
xtables-multi wants to getattr of the proc fs

### DIFF
--- a/policy/modules/system/iptables.te
+++ b/policy/modules/system/iptables.te
@@ -53,6 +53,7 @@ allow iptables_t iptables_tmp_t:dir manage_dir_perms;
 allow iptables_t iptables_tmp_t:file manage_file_perms;
 files_tmp_filetrans(iptables_t, iptables_tmp_t, { file dir })
 
+kernel_getattr_proc(iptables_t)
 kernel_request_load_module(iptables_t)
 kernel_read_system_state(iptables_t)
 kernel_read_network_state(iptables_t)


### PR DESCRIPTION
iptables/xtables-multi for some reasons need the getattr permission on /proc.

```
type=PROCTITLE msg=audit(01/03/18 04:41:03.464:5338) : proctitle=iptables -w -n -L INPUT 
type=SYSCALL msg=audit(01/03/18 04:41:03.464:5338) : arch=x86_64 syscall=statfs success=yes exit=0 a0=0x7f0acb8460b6 a1=0x7ffe218abd10 a2=0x7ffe218abd90 a3=0x0 items=0 ppid=4059 pid=4060 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=iptables exe=/sbin/xtables-multi subj=system_u:system_r:iptables_t:s0 key=(null) 
type=AVC msg=audit(01/03/18 04:41:03.464:5338) : avc:  denied  { getattr } for  pid=4060 comm=iptables name=/ dev="proc" ino=1 scontext=system_u:system_r:iptables_t:s0 tcontext=system_u:object_r:proc_t:s0 tclass=filesystem permissive=1
```

Using strace, it seems that it want to access `/proc/net/ip_tables_names`

This patch is coming from the Red Hat policy